### PR TITLE
Prevent customer creation on backend for invalid wordpress roles with unit tests

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Objects/GOCustomer.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Objects/GOCustomer.php
@@ -8,6 +8,30 @@ class GOCustomer extends \WC_Customer
 {
     const CONTEXT_EDIT = 'edit';
 
+    /**
+     * Role names are based on WP user roles.
+     *
+     * @see https://github.com/WordPress/wordpress-develop/blob/master/tests/phpunit/tests/user/capabilities.php
+     */
+    const CUSTOMER_ROLE_NAME = 'customer';
+    const SUBSCRIBER_ROLE_NAME = 'subscriber';
+    const ADMINISTRATOR_ROLE_NAME = 'administrator';
+    const EDITOR_ROLE_NAME = 'editor';
+    const AUTHOR_ROLE_NAME = 'author';
+    const CONTRIBUTOR_ROLE_NAME = 'contributor';
+
+    const VALID_ROLES = [
+        self::CUSTOMER_ROLE_NAME,
+        self::SUBSCRIBER_ROLE_NAME,
+    ];
+
+    const INVALID_ROLES = [
+        self::ADMINISTRATOR_ROLE_NAME,
+        self::EDITOR_ROLE_NAME,
+        self::AUTHOR_ROLE_NAME,
+        self::CONTRIBUTOR_ROLE_NAME,
+    ];
+
     private $go_api;
 
     protected $data = [
@@ -79,9 +103,14 @@ class GOCustomer extends \WC_Customer
         return $exists;
     }
 
+    public static function isRoleValid(string $role): bool
+    {
+        return in_array($role, self::VALID_ROLES);
+    }
+
     public function sync_customer_to_manage()
     {
-        if (!empty($this->has_storekeeper_id())) {
+        if (!empty($this->has_storekeeper_id()) || !self::isRoleValid($this->get_role())) {
             return $this->get_storekeeper_id();
         }
 

--- a/tests/unit/FileExports/CustomerFileExportTest.php
+++ b/tests/unit/FileExports/CustomerFileExportTest.php
@@ -45,7 +45,6 @@ class CustomerFileExportTest extends AbstractFileExportTest
                     function ($got) {
                         $user = $got[0]['relation'];
                         // Passed firstname as the role in test data
-                        // at self::createUsersWithRoles
                         $role = $user['contact_person']['firstname'];
                         $this->assertNotContains($role, GOCustomer::INVALID_ROLES, $role.' should not be returned');
                         $this->assertContains($role, GOCustomer::VALID_ROLES, $role.' should be returned');

--- a/tests/unit/FileExports/CustomerFileExportTest.php
+++ b/tests/unit/FileExports/CustomerFileExportTest.php
@@ -27,7 +27,7 @@ class CustomerFileExportTest extends AbstractFileExportTest
             ];
         }
         foreach (GOCustomer::INVALID_ROLES as $role) {
-            $invalid[$role] = [
+            $tests[$role] = [
                 $role,
                 false,
             ];

--- a/tests/unit/FileExports/CustomerFileExportTest.php
+++ b/tests/unit/FileExports/CustomerFileExportTest.php
@@ -17,7 +17,23 @@ class CustomerFileExportTest extends AbstractFileExportTest
         return CustomerFileExport::class;
     }
 
-    public function testUserCreateByRoles()
+    public function dataProviderUserCreateByRoles()
+    {
+        $tests = [];
+        foreach (GOCustomer::VALID_ROLES as $role) {
+            $tests['valid-'.$role] = [$role, $role.'_test'];
+        }
+        foreach (GOCustomer::INVALID_ROLES as $role) {
+            $tests['invalid-'.$role] = [$role, $role.'_test'];
+        }
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider dataProviderUserCreateByRoles
+     */
+    public function testUserCreateByRoles($role, $role_name): void
     {
         $this->initApiConnection();
         // Setting is_logged_in to true
@@ -38,12 +54,13 @@ class CustomerFileExportTest extends AbstractFileExportTest
             }
         );
 
-        $this->createUsersWithRoles(
-            array_merge(
-                GOCustomer::VALID_ROLES,
-                GOCustomer::INVALID_ROLES,
-            )
-        );
+        wp_insert_user([
+            'first_name' => $role,
+            'nickname' => $role_name,
+            'user_login' => $role_name,
+            'role' => $role,
+            'user_pass' => $role_name,
+        ]);
     }
 
     public function testCustomerExportTest()
@@ -198,18 +215,5 @@ class CustomerFileExportTest extends AbstractFileExportTest
             $mappedRow['contact_address.street'],
             "Customer's shipping street does not matches"
         );
-    }
-
-    private function createUsersWithRoles(array $roles): void
-    {
-        foreach ($roles as $role) {
-            wp_insert_user([
-                'first_name' => $role,
-                'nickname' => $role.'_test',
-                'user_login' => $role.'_test',
-                'role' => $role,
-                'user_pass' => $role.'_test',
-            ]);
-        }
     }
 }


### PR DESCRIPTION
This PR includes:
1. Only allow `subscriber` and `customer` roles to be synched as customers on backend.
2. Unit tests for user creation to customer synching.