### PR TITLE
Fixed URL for product sync metabox, and storekeeper sync date timezone

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/MetaBoxes/ProductSyncMetaBox.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/MetaBoxes/ProductSyncMetaBox.php
@@ -46,7 +46,7 @@ class ProductSyncMetaBox extends AbstractMetaBox
         $backoffice = '';
         if (0 !== $storekeeperId && StoreKeeperOptions::isConnected()) {
             $backofficeLabel = esc_html__('Open in backoffice', I18N::DOMAIN);
-            $backofficeLink = esc_attr(StoreKeeperOptions::getBackofficeUrl()."#products/details/$storekeeperId");
+            $backofficeLink = esc_attr(StoreKeeperOptions::getBackofficeUrl()."#shop-products/details/$storekeeperId");
             $backoffice = <<<HTML
                         <a href="$backofficeLink" class="product_backoffice_link" target="_blank">$backofficeLabel</a>
                         HTML;

--- a/src/StoreKeeper/WooCommerce/B2C/Exports/OrderExport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Exports/OrderExport.php
@@ -219,8 +219,12 @@ class OrderExport extends AbstractExport
                 update_post_meta($WpObject->get_id(), 'storekeeper_id', $storekeeper_id)
             );
         }
+
+        // Add last sync date meta for orders
+        // Time will be based on user's selected timezone on wordpress
+        $date = current_time('mysql');
         WordpressExceptionThrower::throwExceptionOnWpError(
-            update_post_meta($WpObject->get_id(), 'storekeeper_sync_date', date('Y-m-d H:i:s'))
+            update_post_meta($WpObject->get_id(), 'storekeeper_sync_date', $date)
         );
         $this->debug('Saved order data', $storekeeper_id);
 

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/ProductImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/ProductImport.php
@@ -990,7 +990,9 @@ SQL;
         update_post_meta($newProduct->get_id(), 'storekeeper_id', $dotObject->get('id'));
 
         // Add last sync date meta for products
-        update_post_meta($newProduct->get_id(), 'storekeeper_sync_date', date('Y-m-d H:i:s'));
+        // Time will be based on user's selected timezone on wordpress
+        $date = current_time('mysql');
+        update_post_meta($newProduct->get_id(), 'storekeeper_sync_date', $date);
         $this->debug('storekeeper_id added to post.', $log_data);
 
         if ($dotObject->has('flat_product.content_vars')) {


### PR DESCRIPTION
This PR includes:
1. Changed stored date for product and order sync.
2. Fixed wrong URL on product sync metabox