### PR TITLE
Escaping url bug fix and task rate calculator fix

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractTab.php
@@ -17,7 +17,7 @@ abstract class AbstractTab extends AbstractPageLike
 
     final public function getActionUrl(string $action)
     {
-        return esc_url(add_query_arg('action', $action));
+        return add_query_arg('action', $action);
     }
 
     final private function executeAction(string $action)

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/FormElementTrait.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/FormElementTrait.php
@@ -6,7 +6,7 @@ trait FormElementTrait
 {
     final protected function renderFormStart(string $method = 'get', string $action = null): void
     {
-        $action = esc_attr($action ?? add_query_arg([]));
+        $action = esc_url($action ?? add_query_arg([]));
         $method = esc_attr($method);
 
         echo wp_kses("<form action='$action' method='$method' class='storekeeper-form'>", AbstractPage::ALLOWED_FORM);
@@ -127,7 +127,7 @@ HTML, AbstractPage::ALLOWED_ALL_KNOWN_INPUT);
         string $class = '',
         string $target = '_self'
     ): string {
-        $href = esc_attr($href);
+        $href = esc_url($href);
         $label = esc_html($label);
         $target = esc_attr($target);
 

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/AbstractLogsTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/AbstractLogsTab.php
@@ -99,13 +99,14 @@ abstract class AbstractLogsTab extends AbstractTab
         $sort = $this->getRequestSort();
         // Caret up character
         $caret = '&#9650;';
-        esc_url(remove_query_arg('sort'));
-        $url = esc_url(add_query_arg('sort', 'asc'));
+        remove_query_arg('sort');
+        $url = add_query_arg('sort', 'asc');
         if ('asc' === $sort) {
-            $url = esc_url(add_query_arg('sort', 'desc'));
+            $url = add_query_arg('sort', 'desc');
             // Caret down character
             $caret = '&#9660;';
         }
+        $url = esc_url($url);
         $caret = esc_html($caret);
         $dateString = esc_html__('Date', I18N::DOMAIN);
         echo <<<HTML

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ConnectionTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ConnectionTab.php
@@ -54,7 +54,7 @@ class ConnectionTab extends AbstractTab
         $this->renderFormGroup(
             __('Currently connected to', I18N::DOMAIN),
             esc_html($api).' '.$this->getFormLink(
-                $url,
+                esc_url($url),
                 __('Disconnect', I18N::DOMAIN),
                 'button-primary'
             )

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ExportTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ExportTab.php
@@ -241,7 +241,7 @@ class ExportTab extends AbstractTab
     private function initializeDownload(string $url)
     {
         $basename = esc_js(basename($url));
-        $url = esc_js($url);
+        $url = esc_url($url);
         echo <<<HTML
 <script>
     (function() {

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/TaskLogsTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/TaskLogsTab.php
@@ -11,7 +11,7 @@ class TaskLogsTab extends AbstractLogsTab
     const DO_SINGLE_ACTION = 'do-single-action';
     const DO_MULTIPLE_ACTIONS = 'do-multiple-actions';
     const RETRY_ACTION = 'retry';
-    const MARK_ACTION = 'mark';
+    const MARK_ACTION = 'marks';
 
     public function __construct(string $title, string $slug = '')
     {
@@ -88,7 +88,7 @@ class TaskLogsTab extends AbstractLogsTab
         $this->renderTaskFilter();
 
         $url = $this->getActionUrl(self::DO_MULTIPLE_ACTIONS);
-        $url = esc_attr($url);
+        $url = esc_url($url);
         echo "<form action='$url' method='post'>";
 
         $this->renderTaskMassAction();

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/TaskLogsTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/TaskLogsTab.php
@@ -11,7 +11,7 @@ class TaskLogsTab extends AbstractLogsTab
     const DO_SINGLE_ACTION = 'do-single-action';
     const DO_MULTIPLE_ACTIONS = 'do-multiple-actions';
     const RETRY_ACTION = 'retry';
-    const MARK_ACTION = 'marks';
+    const MARK_ACTION = 'mark';
 
     public function __construct(string $title, string $slug = '')
     {

--- a/src/StoreKeeper/WooCommerce/B2C/Models/AbstractModel.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Models/AbstractModel.php
@@ -107,7 +107,7 @@ abstract class AbstractModel implements IModel
 
     protected static function updateDateField(array $data): array
     {
-        $data['date_updated'] = date('Y-m-d H:i:s');
+        $data['date_updated'] = current_time('mysql', 1);
 
         return $data;
     }

--- a/src/StoreKeeper/WooCommerce/B2C/Models/TaskModel.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Models/TaskModel.php
@@ -94,6 +94,8 @@ SQL;
             'meta_data'
         );
         $data['name'] = static::getName($type, $storekeeper_id);
+        $data['date_created'] = current_time('mysql', 1);
+        static::updateDateField($data);
 
         return static::create($data);
     }


### PR DESCRIPTION
This PR includes:
1. Double escaping error during `getActionUrl`.
2. Changed `TaskModel` creation date and update to `mysql` gmt.