### PR TITLE
Payment settings to be set on by default, and keep state for older stores

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/DashboardTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/DashboardTab.php
@@ -106,6 +106,6 @@ HTML;
 
     private function checkPaymentsActive(): bool
     {
-        return 'yes' === StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'no');
+        return 'yes' === StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'yes');
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Core.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Core.php
@@ -229,7 +229,7 @@ class Core
     private function registerPaymentGateway()
     {
         if (
-            'yes' === StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'no') &&
+            'yes' === StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'yes') &&
             StoreKeeperOptions::isConnected()
         ) {
             //activated the payment gateway and backend is connected, which is required for this feature.

--- a/src/StoreKeeper/WooCommerce/B2C/Updator.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Updator.php
@@ -97,5 +97,12 @@ HTML;
                 $migrate->run();
             }
         }
+
+        if (version_compare($databaseVersion, '7.4.6', '<')) {
+            $currentPaymentGatewayOption = StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED);
+            if ('no' === $currentPaymentGatewayOption || is_null($currentPaymentGatewayOption)) {
+                StoreKeeperOptions::set(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'no');
+            }
+        }
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Updator.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Updator.php
@@ -100,7 +100,7 @@ HTML;
 
         if (version_compare($databaseVersion, '7.4.6', '<')) {
             $currentPaymentGatewayOption = StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED);
-            if ('no' === $currentPaymentGatewayOption || is_null($currentPaymentGatewayOption)) {
+            if (is_null($currentPaymentGatewayOption)) {
                 StoreKeeperOptions::set(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'no');
             }
         }


### PR DESCRIPTION
This PR includes:
1. Keep state of payment gateway for older stores
2. Set fallback of payment gateway to on, but don't save in database.