### PR TITLE
Made WP CLI commands to run on admin mode

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Commands/WpCliCommandRunner.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/WpCliCommandRunner.php
@@ -16,6 +16,17 @@ class WpCliCommandRunner extends CommandRunner
     const command_prefix = 'sk';
     const SINGLE_PROCESS = 'single-process';
 
+    public function __construct()
+    {
+        // WP_ADMIN constant is being defined here as it causes synchronization issue of attribute types due to external plugins
+        // @see known plugin: https://themesinfo.com/wordpress-plugins/wordpress-wpa-woocommerce-variation-swatch-plugin-dksd/latest
+        // @see issue: https://app.clickup.com/t/1tm4vav
+        if (!defined('WP_ADMIN')) {
+            define('WP_ADMIN', true);
+        }
+        parent::__construct();
+    }
+
     /**
      * @throws \Exception
      */

--- a/src/StoreKeeper/WooCommerce/B2C/Tools/Attributes.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tools/Attributes.php
@@ -9,6 +9,7 @@ use Psr\Log\NullLogger;
 use stdClass;
 use StoreKeeper\WooCommerce\B2C\Core;
 use StoreKeeper\WooCommerce\B2C\Exceptions\WordpressException;
+use StoreKeeper\WooCommerce\B2C\I18N;
 use StoreKeeper\WooCommerce\B2C\Models\AttributeModel;
 use StoreKeeper\WooCommerce\B2C\Models\AttributeOptionModel;
 use StoreKeeper\WooCommerce\B2C\Objects\PluginStatus;
@@ -445,6 +446,11 @@ class Attributes
         string $alias,
         string $title
     ): int {
+        // Refer admin issue on StoreKeeper\WooCommerce\B2C\Commands\WpCliCommandRunner::21
+        if (!is_admin()) {
+            throw new WordpressException(__('Failed to execute attribute sync as WP_ADMIN constant is set to false', I18N::DOMAIN));
+        }
+
         $existingAttribute = self::getAttribute($storekeeper_id);
         if (empty($existingAttribute)) {
             // maybe the attribute was deleted on the StoreKeper site and recreated (alias cannot be changed)
@@ -468,7 +474,6 @@ class Attributes
             $update_arguments['type'] = self::getDefaultType();
             $update_arguments['slug'] = self::prepareNewAttributeSlug($alias);
             $update_arguments['has_archives'] = self::DEFAULT_ARCHIVED_SETTING;
-
             $attribute_id = WordpressExceptionThrower::throwExceptionOnWpError(
                 wc_create_attribute($update_arguments)
             );

--- a/tests/unit/Commands/CommandRunnerTrait.php
+++ b/tests/unit/Commands/CommandRunnerTrait.php
@@ -20,6 +20,8 @@ trait CommandRunnerTrait
     public function setUpRunner()
     {
         $this->logger = new TestLogger();
+        // Refer admin issue on StoreKeeper\WooCommerce\B2C\Commands\WpCliCommandRunner::21
+        define('WP_ADMIN', true);
         $this->runner = Core::getCommandRunner();
         $this->runner->setLogger($this->logger);
     }


### PR DESCRIPTION
This PR includes:
1. Fix for attributes type reverted to `select` when executed via CLI.
2. Added setting of constant `WP_ADMIN` to true when running using WpCliCommandRunner.

Reason:
WPA swatch plugin is not registering hooks if not admin
![image](https://user-images.githubusercontent.com/18332309/142874538-cbded386-1cae-4082-a31d-ab978dfea217.png)
![image](https://user-images.githubusercontent.com/18332309/142874708-c1725ff9-5efd-4a52-bafa-0a3b724e8cdb.png)


Attached screenshots of testing in clickup card.
https://app.clickup.com/t/1tm4vav
