### PR TITLE
Added new sync modes and order sync from date

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/MetaBoxes/OrderSyncMetaBox.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/MetaBoxes/OrderSyncMetaBox.php
@@ -56,6 +56,17 @@ class OrderSyncMetaBox extends AbstractMetaBox
         }
 
         $submitLabel = esc_html__('Force sync', I18N::DOMAIN);
+
+        $manualSyncWarning = '';
+        if (!StoreKeeperOptions::isOrderSyncEnabled()) {
+            $manualSyncWarningText = __("All orders won't be synced automatically with your currently selected Synchronization mode, but you can do it manually using the Force sync below", I18N::DOMAIN);
+            $manualSyncWarning = <<<HTML
+                <li class="wide">
+                    <small class="text-danger">$manualSyncWarningText</small>
+                </li>
+            HTML;
+        }
+
         echo <<<HTML
             <ul class="order_actions submitbox">
                 <li class="wide">
@@ -72,6 +83,7 @@ class OrderSyncMetaBox extends AbstractMetaBox
                     <a href="$syncUrl" class="button-primary order_sync_submission">$submitLabel</a>
                     $backoffice
                 </li>
+                $manualSyncWarning
             </ul>
             HTML;
 

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/MetaBoxes/OrderSyncMetaBox.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/MetaBoxes/OrderSyncMetaBox.php
@@ -59,7 +59,7 @@ class OrderSyncMetaBox extends AbstractMetaBox
 
         $manualSyncWarning = '';
         if (!StoreKeeperOptions::isOrderSyncEnabled()) {
-            $manualSyncWarningText = __("All orders won't be synced automatically with your currently selected Synchronization mode, but you can do it manually using the Force sync below", I18N::DOMAIN);
+            $manualSyncWarningText = esc_html__("All orders won't be synced automatically with your currently selected Synchronization mode, but you can do it manually using the Force sync button", I18N::DOMAIN);
             $manualSyncWarning = <<<HTML
                 <li class="wide">
                     <small class="text-danger">$manualSyncWarningText</small>

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/FormElementTrait.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/FormElementTrait.php
@@ -98,13 +98,15 @@ HTML, HtmlEscape::ALLOWED_ALL_KNOWN_INPUT);
     final protected function getFormCheckbox(
         string $name,
         bool $value = false,
-        string $class = ''
+        string $class = '',
+        bool $isDisabled = false
     ): string {
         $name = esc_attr($name);
         $checked = esc_attr($value) ? 'checked' : '';
+        $disabled = esc_attr($isDisabled) ? 'disabled="disabled"' : '';
         $class = esc_attr($class);
 
-        return "<input type='checkbox' class='$class' name='$name' $checked />";
+        return "<input type='checkbox' class='$class' name='$name' $checked $disabled/>";
     }
 
     final protected function getFormButton(

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ConnectionTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ConnectionTab.php
@@ -138,9 +138,7 @@ class ConnectionTab extends AbstractTab
         $this->renderFormHeader(__('Synchronization settings', I18N::DOMAIN));
 
         $this->renderSyncModeSetting();
-        if (!EventsHandler::isEventsDisabled('orders')) {
-            $this->renderOrderSyncFromDate();
-        }
+        $this->renderOrderSyncFromDate();
         $this->renderPaymentSetting();
         $this->renderBackorderSetting();
         $this->renderBarcodeModeSetting();

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ConnectionTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/ConnectionTab.php
@@ -4,7 +4,6 @@ namespace StoreKeeper\WooCommerce\B2C\Backoffice\Pages\Tabs;
 
 use StoreKeeper\WooCommerce\B2C\Backoffice\Pages\AbstractTab;
 use StoreKeeper\WooCommerce\B2C\Backoffice\Pages\FormElementTrait;
-use StoreKeeper\WooCommerce\B2C\Endpoints\Webhooks\EventsHandler;
 use StoreKeeper\WooCommerce\B2C\I18N;
 use StoreKeeper\WooCommerce\B2C\Models\TaskModel;
 use StoreKeeper\WooCommerce\B2C\Models\WebhookLogModel;
@@ -322,7 +321,7 @@ HTML;
     {
         $paymentName = StoreKeeperOptions::getConstant(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED);
         $extraInfo = '';
-        if (EventsHandler::isEventsDisabled('payments')) {
+        if (!StoreKeeperOptions::isPaymentSyncEnabled()) {
             $extraInfo = '<br><small>'.__('Payments are disabled in currently selected Synchronization mode').'</small>';
         }
         $this->renderFormGroup(
@@ -330,7 +329,7 @@ HTML;
             $this->getFormCheckbox(
                 $paymentName,
                 'yes' === StoreKeeperOptions::get($paymentName),
-                EventsHandler::isEventsDisabled('payments') ? 'disabled' : '',
+                StoreKeeperOptions::isPaymentSyncEnabled() ? '' : 'disabled',
             ).' '.__(
                 'When checked, active webshop payment methods from your StoreKeeper backoffice are added to your webshop\'s checkout',
                 I18N::DOMAIN

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/static/default.page.css
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/static/default.page.css
@@ -97,3 +97,8 @@ p.storekeeper-form-note {
 .text-information {
     color: #3498db !important;
 }
+
+/* Making sure disabled inputs by classes are not clickable */
+input[type="checkbox"].disabled {
+    pointer-events: none;
+}

--- a/src/StoreKeeper/WooCommerce/B2C/Core.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Core.php
@@ -51,6 +51,7 @@ use StoreKeeper\WooCommerce\B2C\Commands\WpCliCommandRunner;
 use StoreKeeper\WooCommerce\B2C\Cron\CronRegistrar;
 use StoreKeeper\WooCommerce\B2C\Cron\ProcessTaskCron;
 use StoreKeeper\WooCommerce\B2C\Endpoints\EndpointLoader;
+use StoreKeeper\WooCommerce\B2C\Endpoints\Webhooks\EventsHandler;
 use StoreKeeper\WooCommerce\B2C\Exceptions\BootError;
 use StoreKeeper\WooCommerce\B2C\Frontend\FrondendCore;
 use StoreKeeper\WooCommerce\B2C\Hooks\CustomerHook;
@@ -132,14 +133,20 @@ class Core
 
         $this->setUpdateCheck();
         $this->setLocale();
-        $this->setOrderHooks();
-        $this->setCustomerHooks();
+        if (!EventsHandler::isEventsDisabled('orders')) {
+            $this->setOrderHooks();
+        }
+        if (!EventsHandler::isEventsDisabled('customers')) {
+            $this->setCustomerHooks();
+        }
         $this->setCouponHooks();
         $this->prepareCron();
-        $this->registerCommands();
+        self::registerCommands();
         $this->loadAdditionalCore();
         $this->loadEndpoints();
-        $this->registerPaymentGateway();
+        if (!EventsHandler::isEventsDisabled('payments')) {
+            $this->registerPaymentGateway();
+        }
         $this->versionChecks();
     }
 

--- a/src/StoreKeeper/WooCommerce/B2C/Core.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Core.php
@@ -51,7 +51,6 @@ use StoreKeeper\WooCommerce\B2C\Commands\WpCliCommandRunner;
 use StoreKeeper\WooCommerce\B2C\Cron\CronRegistrar;
 use StoreKeeper\WooCommerce\B2C\Cron\ProcessTaskCron;
 use StoreKeeper\WooCommerce\B2C\Endpoints\EndpointLoader;
-use StoreKeeper\WooCommerce\B2C\Endpoints\Webhooks\EventsHandler;
 use StoreKeeper\WooCommerce\B2C\Exceptions\BootError;
 use StoreKeeper\WooCommerce\B2C\Frontend\FrondendCore;
 use StoreKeeper\WooCommerce\B2C\Hooks\CustomerHook;
@@ -133,10 +132,10 @@ class Core
 
         $this->setUpdateCheck();
         $this->setLocale();
-        if (!EventsHandler::isEventsDisabled('orders')) {
+        if (StoreKeeperOptions::isOrderSyncEnabled()) {
             $this->setOrderHooks();
         }
-        if (!EventsHandler::isEventsDisabled('customers')) {
+        if (StoreKeeperOptions::isCustomerSyncEnabled()) {
             $this->setCustomerHooks();
         }
         $this->setCouponHooks();
@@ -144,7 +143,7 @@ class Core
         self::registerCommands();
         $this->loadAdditionalCore();
         $this->loadEndpoints();
-        if (!EventsHandler::isEventsDisabled('payments')) {
+        if (StoreKeeperOptions::isPaymentSyncEnabled()) {
             $this->registerPaymentGateway();
         }
         $this->versionChecks();

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
@@ -27,21 +27,6 @@ class EventsHandler
 
     private $id;
 
-    const MODES_WITHOUT_CUSTOMERS_SYNC = [
-        StoreKeeperOptions::SYNC_MODE_PRODUCT_ONLY,
-        StoreKeeperOptions::SYNC_MODE_NONE,
-    ];
-
-    const MODES_WITHOUT_ORDERS_SYNC = [
-        StoreKeeperOptions::SYNC_MODE_PRODUCT_ONLY,
-        StoreKeeperOptions::SYNC_MODE_NONE,
-    ];
-
-    const MODES_WITHOUT_PAYMENTS = [
-        StoreKeeperOptions::SYNC_MODE_PRODUCT_ONLY,
-        StoreKeeperOptions::SYNC_MODE_NONE,
-    ];
-
     /**
      * @return mixed
      */
@@ -168,105 +153,15 @@ class EventsHandler
         foreach ($events as $id => $event) {
             $details = $event['details'] ?? [];
             $eventType = $event['event'];
-            switch ("$module::$eventType") {
-                // ShopModule::ShopProduct
-                case 'ShopModule::ShopProduct::updated':
-                case 'ShopModule::ShopProduct::created':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'ShopModule::ShopProduct::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
-                    break;
-                case 'ShopModule::ShopProduct::deactivated':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_DEACTIVATED, $this->getId(), $taskData, true);
-                    break;
-                case 'ShopModule::ShopProduct::activated':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_ACTIVATED, $this->getId(), $taskData, true);
-                    break;
-                // ShopModule::Order
-                case 'ShopModule::Order::updated':
-                    $metaData = [
-                        'old_order' => json_encode($details['old_order']),
-                        'order' => json_encode($details['order']),
-                    ];
-                    TaskHandler::scheduleTask(
-                        TaskHandler::ORDERS_IMPORT,
-                        $this->getId(),
-                        array_merge($taskData, $metaData),
-                        true
-                    );
-                    break;
-                case 'ShopModule::Order::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
-                    break;
-                // BlogModule::Category
-                case 'BlogModule::Category::updated':
-                case 'BlogModule::Category::created':
-                    if ('category' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::CATEGORY_IMPORT, $this->getId(), $taskData);
-                    }
-                    if ('label' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::TAG_IMPORT, $this->getId(), $taskData);
-                    }
-                    break;
-                case 'BlogModule::Category::deleted':
-                    if ('category' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::CATEGORY_DELETE, $this->getId(), $taskData);
-                    }
-                    if ('label' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::TAG_DELETE, $this->getId(), $taskData);
-                    }
-                    break;
-                // ShopModule::CouponCode
-                case 'ShopModule::CouponCode::updated':
-                case 'ShopModule::CouponCode::created':
-                    $taskData = array_merge(
-                        $taskData,
-                        [
-                            'code' => $details['code'] ?? null,
-                        ]
-                    );
-                    TaskHandler::scheduleTask(TaskHandler::COUPON_CODE_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'ShopModule::CouponCode::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::COUPON_CODE_DELETE, $this->getId(), $taskData);
-                    $taskData = array_merge(
-                        $taskData,
-                        [
-                            'code' => $details['code'],
-                        ]
-                    );
-                    break;
-                // ProductsModule::FeaturedAttribute
-                case 'ProductsModule::FeaturedAttribute::updated':
-                    $alias = $details['alias'];
-                    FeaturedAttributeOptions::setAttribute(
-                        $alias,
-                        $details['attribute_id'],
-                        $details['attribute']['name']
-                    );
-                    break;
-                case 'ProductsModule::FeaturedAttribute::deleted':
-                    $alias = $details['alias'];
-                    FeaturedAttributeOptions::deleteAttribute($alias);
-                    break;
-                // BlogModule::MenuItem
-                case 'BlogModule::MenuItem::updated':
-                case 'BlogModule::MenuItem::created':
-                    TaskHandler::scheduleTask(TaskHandler::MENU_ITEM_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'BlogModule::MenuItem::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::MENU_ITEM_DELETE, $this->getId(), $taskData);
-                    break;
-                // BlogModule::SiteRedirect
-                case 'BlogModule::SiteRedirect::updated':
-                case 'BlogModule::SiteRedirect::created':
-                    TaskHandler::scheduleTask(TaskHandler::REDIRECT_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'BlogModule::SiteRedirect::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::REDIRECT_DELETE, $this->getId(), $taskData);
-                    break;
-            }
+            $fullEventType = "$module::$eventType";
+
+            $this->handleProductEvents($fullEventType, $taskData);
+            $this->handleCategoryEvents($fullEventType, $taskData, $categoryType);
+            $this->handleCouponCodeEvents($fullEventType, $taskData, $details);
+            $this->handleOrderEvents($fullEventType, $taskData, $details);
+            $this->handleFeaturedAttributeEvents($fullEventType, $details);
+            $this->handleMenuItemEvents($fullEventType, $taskData);
+            $this->handleSiteRedirectEvents($fullEventType, $taskData);
         }
     }
 
@@ -284,89 +179,14 @@ class EventsHandler
         foreach ($events as $id => $event) {
             $details = $event['details'] ?? [];
             $eventType = $event['event'];
-            switch ("$module::$eventType") {
-                // ShopModule::ShopProduct
-                case 'ShopModule::ShopProduct::updated':
-                case 'ShopModule::ShopProduct::created':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'ShopModule::ShopProduct::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
-                    break;
-                case 'ShopModule::ShopProduct::deactivated':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_DEACTIVATED, $this->getId(), $taskData, true);
-                    break;
-                case 'ShopModule::ShopProduct::activated':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_ACTIVATED, $this->getId(), $taskData, true);
-                    break;
-                // BlogModule::Category
-                case 'BlogModule::Category::updated':
-                case 'BlogModule::Category::created':
-                    if ('category' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::CATEGORY_IMPORT, $this->getId(), $taskData);
-                    }
-                    if ('label' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::TAG_IMPORT, $this->getId(), $taskData);
-                    }
-                    break;
-                case 'BlogModule::Category::deleted':
-                    if ('category' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::CATEGORY_DELETE, $this->getId(), $taskData);
-                    }
-                    if ('label' === $categoryType) {
-                        TaskHandler::scheduleTask(TaskHandler::TAG_DELETE, $this->getId(), $taskData);
-                    }
-                    break;
-                // ShopModule::CouponCode
-                case 'ShopModule::CouponCode::updated':
-                case 'ShopModule::CouponCode::created':
-                    $taskData = array_merge(
-                        $taskData,
-                        [
-                            'code' => $details['code'] ?? null,
-                        ]
-                    );
-                    TaskHandler::scheduleTask(TaskHandler::COUPON_CODE_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'ShopModule::CouponCode::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::COUPON_CODE_DELETE, $this->getId(), $taskData);
-                    $taskData = array_merge(
-                        $taskData,
-                        [
-                            'code' => $details['code'],
-                        ]
-                    );
-                    break;
-                // ProductsModule::FeaturedAttribute
-                case 'ProductsModule::FeaturedAttribute::updated':
-                    $alias = $details['alias'];
-                    FeaturedAttributeOptions::setAttribute(
-                        $alias,
-                        $details['attribute_id'],
-                        $details['attribute']['name']
-                    );
-                    break;
-                case 'ProductsModule::FeaturedAttribute::deleted':
-                    $alias = $details['alias'];
-                    FeaturedAttributeOptions::deleteAttribute($alias);
-                    break;
-                // BlogModule::MenuItem
-                case 'BlogModule::MenuItem::updated':
-                case 'BlogModule::MenuItem::created':
-                    TaskHandler::scheduleTask(TaskHandler::MENU_ITEM_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'BlogModule::MenuItem::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::MENU_ITEM_DELETE, $this->getId(), $taskData);
-                    break;
-                // BlogModule::SiteRedirect
-                case 'BlogModule::SiteRedirect::updated':
-                case 'BlogModule::SiteRedirect::created':
-                    TaskHandler::scheduleTask(TaskHandler::REDIRECT_IMPORT, $this->getId(), $taskData);
-                    break;
-                case 'BlogModule::SiteRedirect::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::REDIRECT_DELETE, $this->getId(), $taskData);
-                    break;
-            }
+            $fullEventType = "$module::$eventType";
+
+            $this->handleProductEvents($fullEventType, $taskData);
+            $this->handleCategoryEvents($fullEventType, $taskData, $categoryType);
+            $this->handleCouponCodeEvents($fullEventType, $taskData, $details);
+            $this->handleFeaturedAttributeEvents($fullEventType, $details);
+            $this->handleMenuItemEvents($fullEventType, $taskData);
+            $this->handleSiteRedirectEvents($fullEventType, $taskData);
         }
     }
 
@@ -382,30 +202,152 @@ class EventsHandler
         foreach ($events as $id => $event) {
             $details = $event['details'] ?? [];
             $eventType = $event['event'];
-            switch ("$module::$eventType") {
+
+            $fullEventType = "$module::$eventType";
+
+            $this->handleOrderEvents($fullEventType, $taskData, $details);
+
+            switch ($fullEventType) {
                 // ShopModule::ShopProduct
                 case 'ShopModule::ShopProduct::created':
                 case 'ShopModule::ShopProduct::updated':
                 case 'ShopModule::ShopProduct::activated':
                     TaskHandler::scheduleTask(TaskHandler::PRODUCT_STOCK_UPDATE, $this->getId(), $taskData);
                     break;
-                // ShopModule::Order
-                case 'ShopModule::Order::updated':
-                    $metaData = [
-                        'old_order' => json_encode($details['old_order']),
-                        'order' => json_encode($details['order']),
-                    ];
-                    TaskHandler::scheduleTask(
-                        TaskHandler::ORDERS_IMPORT,
-                        $this->getId(),
-                        array_merge($taskData, $metaData),
-                        true
-                    );
-                    break;
-                case 'ShopModule::Order::deleted':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
-                    break;
             }
+        }
+    }
+
+    private function handleProductEvents(string $eventType, array $taskData): void
+    {
+        switch ($eventType) {
+            // ShopModule::ShopProduct
+            case 'ShopModule::ShopProduct::updated':
+            case 'ShopModule::ShopProduct::created':
+                TaskHandler::scheduleTask(TaskHandler::PRODUCT_IMPORT, $this->getId(), $taskData);
+                break;
+            case 'ShopModule::ShopProduct::deleted':
+                TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
+                break;
+            case 'ShopModule::ShopProduct::deactivated':
+                TaskHandler::scheduleTask(TaskHandler::PRODUCT_DEACTIVATED, $this->getId(), $taskData, true);
+                break;
+            case 'ShopModule::ShopProduct::activated':
+                TaskHandler::scheduleTask(TaskHandler::PRODUCT_ACTIVATED, $this->getId(), $taskData, true);
+                break;
+        }
+    }
+
+    private function handleCategoryEvents(string $eventType, array $taskData, string $categoryType): void
+    {
+        switch ($eventType) {
+            // BlogModule::Category
+            case 'BlogModule::Category::updated':
+            case 'BlogModule::Category::created':
+                if ('category' === $categoryType) {
+                    TaskHandler::scheduleTask(TaskHandler::CATEGORY_IMPORT, $this->getId(), $taskData);
+                }
+                if ('label' === $categoryType) {
+                    TaskHandler::scheduleTask(TaskHandler::TAG_IMPORT, $this->getId(), $taskData);
+                }
+                break;
+            case 'BlogModule::Category::deleted':
+                if ('category' === $categoryType) {
+                    TaskHandler::scheduleTask(TaskHandler::CATEGORY_DELETE, $this->getId(), $taskData);
+                }
+                if ('label' === $categoryType) {
+                    TaskHandler::scheduleTask(TaskHandler::TAG_DELETE, $this->getId(), $taskData);
+                }
+                break;
+        }
+    }
+
+    private function handleCouponCodeEvents(string $eventType, array $taskData, array $details): void
+    {
+        switch ($eventType) {
+            // ShopModule::CouponCode
+            case 'ShopModule::CouponCode::updated':
+            case 'ShopModule::CouponCode::created':
+                $taskData = array_merge(
+                    $taskData,
+                    [
+                        'code' => $details['code'] ?? null,
+                    ]
+                );
+                TaskHandler::scheduleTask(TaskHandler::COUPON_CODE_IMPORT, $this->getId(), $taskData);
+                break;
+            case 'ShopModule::CouponCode::deleted':
+                TaskHandler::scheduleTask(TaskHandler::COUPON_CODE_DELETE, $this->getId(), $taskData);
+                break;
+        }
+    }
+
+    private function handleOrderEvents(string $eventType, array $taskData, array $details): void
+    {
+        switch ($eventType) {
+            // ShopModule::Order
+            case 'ShopModule::Order::updated':
+                $metaData = [
+                    'old_order' => json_encode($details['old_order'], JSON_THROW_ON_ERROR),
+                    'order' => json_encode($details['order'], JSON_THROW_ON_ERROR),
+                ];
+                TaskHandler::scheduleTask(
+                    TaskHandler::ORDERS_IMPORT,
+                    $this->getId(),
+                    array_merge($taskData, $metaData),
+                    true
+                );
+                break;
+            case 'ShopModule::Order::deleted':
+                TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
+                break;
+        }
+    }
+
+    private function handleFeaturedAttributeEvents(string $eventType, array $details): void
+    {
+        switch ($eventType) {
+            // ProductsModule::FeaturedAttribute
+            case 'ProductsModule::FeaturedAttribute::updated':
+                $alias = $details['alias'];
+                FeaturedAttributeOptions::setAttribute(
+                    $alias,
+                    $details['attribute_id'],
+                    $details['attribute']['name']
+                );
+                break;
+            case 'ProductsModule::FeaturedAttribute::deleted':
+                $alias = $details['alias'];
+                FeaturedAttributeOptions::deleteAttribute($alias);
+                break;
+        }
+    }
+
+    private function handleMenuItemEvents(string $eventType, array $taskData): void
+    {
+        switch ($eventType) {
+            // BlogModule::MenuItem
+            case 'BlogModule::MenuItem::updated':
+            case 'BlogModule::MenuItem::created':
+                TaskHandler::scheduleTask(TaskHandler::MENU_ITEM_IMPORT, $this->getId(), $taskData);
+                break;
+            case 'BlogModule::MenuItem::deleted':
+                TaskHandler::scheduleTask(TaskHandler::MENU_ITEM_DELETE, $this->getId(), $taskData);
+                break;
+        }
+    }
+
+    private function handleSiteRedirectEvents(string $eventType, array $taskData): void
+    {
+        switch ($eventType) {
+            // BlogModule::SiteRedirect
+            case 'BlogModule::SiteRedirect::updated':
+            case 'BlogModule::SiteRedirect::created':
+                TaskHandler::scheduleTask(TaskHandler::REDIRECT_IMPORT, $this->getId(), $taskData);
+                break;
+            case 'BlogModule::SiteRedirect::deleted':
+                TaskHandler::scheduleTask(TaskHandler::REDIRECT_DELETE, $this->getId(), $taskData);
+                break;
         }
     }
 
@@ -505,23 +447,5 @@ class EventsHandler
         }
 
         return false;
-    }
-
-    public static function isEventsDisabled(string $eventType): bool
-    {
-        $disabled = false;
-        if ('orders' === $eventType) {
-            $disabled = in_array(StoreKeeperOptions::getSyncMode(), self::MODES_WITHOUT_ORDERS_SYNC, true);
-        }
-
-        if ('customers' === $eventType) {
-            $disabled = in_array(StoreKeeperOptions::getSyncMode(), self::MODES_WITHOUT_CUSTOMERS_SYNC, true);
-        }
-
-        if ('payments' === $eventType) {
-            $disabled = in_array(StoreKeeperOptions::getSyncMode(), self::MODES_WITHOUT_PAYMENTS, true);
-        }
-
-        return $disabled;
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
@@ -262,7 +262,7 @@ class EventsHandler
         }
     }
 
-    private function handleCouponCodeEvents(string $eventType, array $taskData, array $details): void
+    private function handleCouponCodeEvents(string $eventType, array $taskData, $details): void
     {
         switch ($eventType) {
             // ShopModule::CouponCode
@@ -282,7 +282,7 @@ class EventsHandler
         }
     }
 
-    private function handleOrderEvents(string $eventType, array $taskData, array $details): void
+    private function handleOrderEvents(string $eventType, array $taskData, $details): void
     {
         switch ($eventType) {
             // ShopModule::Order
@@ -304,7 +304,7 @@ class EventsHandler
         }
     }
 
-    private function handleFeaturedAttributeEvents(string $eventType, array $details): void
+    private function handleFeaturedAttributeEvents(string $eventType, $details): void
     {
         switch ($eventType) {
             // ProductsModule::FeaturedAttribute

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
@@ -206,15 +206,7 @@ class EventsHandler
             $fullEventType = "$module::$eventType";
 
             $this->handleOrderEvents($fullEventType, $taskData, $details);
-
-            switch ($fullEventType) {
-                // ShopModule::ShopProduct
-                case 'ShopModule::ShopProduct::created':
-                case 'ShopModule::ShopProduct::updated':
-                case 'ShopModule::ShopProduct::activated':
-                    TaskHandler::scheduleTask(TaskHandler::PRODUCT_STOCK_UPDATE, $this->getId(), $taskData);
-                    break;
-            }
+            $this->handleProductStockEvents($fullEventType, $taskData);
         }
     }
 
@@ -234,6 +226,19 @@ class EventsHandler
                 break;
             case 'ShopModule::ShopProduct::activated':
                 TaskHandler::scheduleTask(TaskHandler::PRODUCT_ACTIVATED, $this->getId(), $taskData, true);
+                break;
+        }
+    }
+
+    private function handleProductStockEvents(string $eventType, array $taskData): void
+    {
+        switch ($eventType) {
+            // ShopModule::ShopProduct
+            // For product stock only
+            case 'ShopModule::ShopProduct::created':
+            case 'ShopModule::ShopProduct::updated':
+            case 'ShopModule::ShopProduct::activated':
+                TaskHandler::scheduleTask(TaskHandler::PRODUCT_STOCK_UPDATE, $this->getId(), $taskData);
                 break;
         }
     }

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
@@ -83,7 +83,7 @@ class InfoHandler
             'task_failed_quantity' => TaskModel::countFailedTasks(),
             'task_successful_quantity' => TaskModel::countSuccessfulTasks(),
             'hook_quantity' => WebhookLogModel::count(),
-            'active_capability' => [], // TODO: Discussion with Szymon
+            'active_capability' => self::getActiveCapabilities(),
         ];
 
         foreach (self::EXTRA_BLOG_INFO_FIELDS as $blogInfoField) {
@@ -94,6 +94,19 @@ class InfoHandler
         }
 
         return $extras;
+    }
+
+    public static function getActiveCapabilities(): array
+    {
+        $activeCapabilities = [];
+        if (
+            !EventsHandler::isEventsDisabled('payments') &&
+            'yes' === StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'yes')
+        ) {
+            $activeCapabilities[] = 'b2s_payment_method';
+        }
+
+        return $activeCapabilities;
     }
 
     public static function getLastHookDate(): ?string

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
@@ -83,6 +83,7 @@ class InfoHandler
             'task_failed_quantity' => TaskModel::countFailedTasks(),
             'task_successful_quantity' => TaskModel::countSuccessfulTasks(),
             'hook_quantity' => WebhookLogModel::count(),
+            'active_capability' => [], // TODO: Discussion with Szymon
         ];
 
         foreach (self::EXTRA_BLOG_INFO_FIELDS as $blogInfoField) {

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
@@ -100,7 +100,7 @@ class InfoHandler
     {
         $activeCapabilities = [];
         if (
-            !EventsHandler::isEventsDisabled('payments') &&
+            StoreKeeperOptions::isPaymentSyncEnabled() &&
             'yes' === StoreKeeperOptions::get(StoreKeeperOptions::PAYMENT_GATEWAY_ACTIVATED, 'yes')
         ) {
             $activeCapabilities[] = 'b2s_payment_method';

--- a/src/StoreKeeper/WooCommerce/B2C/Helpers/HtmlEscape.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Helpers/HtmlEscape.php
@@ -39,6 +39,14 @@ class HtmlEscape
             'class' => [],
             'style' => [],
         ],
+        'strong' => [
+            'class' => [],
+            'style' => [],
+        ],
+        'b' => [
+            'class' => [],
+            'style' => [],
+        ],
     ];
 
     public const ALLOWED_FORM = [
@@ -68,6 +76,7 @@ class HtmlEscape
             'value' => [],
             'placeholder' => [],
             'checked' => [],
+            'disabled' => [],
         ],
     ] + self::ALLOWED_COMMON;
 

--- a/src/StoreKeeper/WooCommerce/B2C/Options/StoreKeeperOptions.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Options/StoreKeeperOptions.php
@@ -23,6 +23,21 @@ class StoreKeeperOptions extends AbstractOptions
     const SYNC_MODE_PRODUCT_ONLY = 'sync-mode-product-only';
     const SYNC_MODE_NONE = 'sync-mode-none';
 
+    const MODES_WITH_CUSTOMERS_SYNC = [
+        StoreKeeperOptions::SYNC_MODE_FULL_SYNC,
+        StoreKeeperOptions::SYNC_MODE_ORDER_ONLY,
+    ];
+
+    const MODES_WITH_ORDERS_SYNC = [
+        StoreKeeperOptions::SYNC_MODE_FULL_SYNC,
+        StoreKeeperOptions::SYNC_MODE_ORDER_ONLY,
+    ];
+
+    const MODES_WITH_PAYMENTS = [
+        StoreKeeperOptions::SYNC_MODE_FULL_SYNC,
+        StoreKeeperOptions::SYNC_MODE_ORDER_ONLY,
+    ];
+
     const ORDER_SYNC_FROM_DATE = 'sync-order-from-date';
 
     const BARCODE_MODE = 'barcode-mode';
@@ -126,5 +141,20 @@ class StoreKeeperOptions extends AbstractOptions
         }
 
         return ['', '', '', ''];
+    }
+
+    public static function isOrderSyncEnabled(): bool
+    {
+        return in_array(self::getSyncMode(), self::MODES_WITH_ORDERS_SYNC, true);
+    }
+
+    public static function isCustomerSyncEnabled(): bool
+    {
+        return in_array(self::getSyncMode(), self::MODES_WITH_CUSTOMERS_SYNC, true);
+    }
+
+    public static function isPaymentSyncEnabled(): bool
+    {
+        return in_array(self::getSyncMode(), self::MODES_WITH_PAYMENTS, true);
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Options/StoreKeeperOptions.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Options/StoreKeeperOptions.php
@@ -19,6 +19,10 @@ class StoreKeeperOptions extends AbstractOptions
 
     const SYNC_MODE_FULL_SYNC = 'sync-mode-full-sync';
     const SYNC_MODE_ORDER_ONLY = 'sync-mode-order-only';
+    const SYNC_MODE_PRODUCT_ONLY = 'sync-mode-product-only';
+    const SYNC_MODE_NONE = 'sync-mode-none';
+
+    const ORDER_SYNC_FROM_DATE = 'sync-order-from-date';
 
     const BARCODE_MODE = 'barcode-mode';
     const BARCODE_META_FALLBACK = 'storekeeper_barcode';

--- a/src/StoreKeeper/WooCommerce/B2C/Tools/OrderHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tools/OrderHandler.php
@@ -2,6 +2,8 @@
 
 namespace StoreKeeper\WooCommerce\B2C\Tools;
 
+use StoreKeeper\WooCommerce\B2C\Endpoints\Webhooks\EventsHandler;
+use StoreKeeper\WooCommerce\B2C\Options\StoreKeeperOptions;
 use WP_Post;
 
 class OrderHandler
@@ -13,8 +15,12 @@ class OrderHandler
      *
      * @throws \Exception
      */
-    public function create($order_id): array
+    public function create($order_id): ?array
     {
+        if (!$this->isSyncAllowed($order_id)) {
+            return null;
+        }
+
         return TaskHandler::scheduleTask(
             TaskHandler::ORDERS_EXPORT,
             $order_id,
@@ -33,6 +39,10 @@ class OrderHandler
     {
         global $storekeeper_ignore_order_id;
 
+        if (!$this->isSyncAllowed($order_id)) {
+            return;
+        }
+
         if ($storekeeper_ignore_order_id === $order_id) {
             return;
         }
@@ -50,6 +60,7 @@ class OrderHandler
         );
     }
 
+    /* @deprecated  */
     public function delete($order_id): WP_Post
     {
         $meta_data = [];
@@ -91,5 +102,24 @@ class OrderHandler
         }
 
         $order->add_meta_data(self::SHOP_PRODUCT_ID_MAP, $id_map);
+    }
+
+    protected function isSyncAllowed(int $orderId): bool
+    {
+        if (EventsHandler::isEventsDisabled('orders')) {
+            return false;
+        }
+
+        if (0 !== $orderId) {
+            $order = new \WC_Order($orderId);
+            $orderCreatedDate = $order->get_date_created();
+            $orderCreatedDate = date('Y-m-d', strtotime($orderCreatedDate));
+            $orderSyncFromDate = StoreKeeperOptions::get(StoreKeeperOptions::ORDER_SYNC_FROM_DATE);
+            if (!is_null($orderSyncFromDate) && strtotime($orderCreatedDate) < strtotime($orderSyncFromDate)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Tools/OrderHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tools/OrderHandler.php
@@ -2,7 +2,6 @@
 
 namespace StoreKeeper\WooCommerce\B2C\Tools;
 
-use StoreKeeper\WooCommerce\B2C\Endpoints\Webhooks\EventsHandler;
 use StoreKeeper\WooCommerce\B2C\Options\StoreKeeperOptions;
 use WP_Post;
 
@@ -106,20 +105,16 @@ class OrderHandler
 
     protected function isSyncAllowed(int $orderId): bool
     {
-        if (EventsHandler::isEventsDisabled('orders')) {
-            return false;
-        }
-
-        if (0 !== $orderId) {
+        if (StoreKeeperOptions::isOrderSyncEnabled()) {
             $order = new \WC_Order($orderId);
             $orderCreatedDate = $order->get_date_created();
             $orderCreatedDate = date('Y-m-d', strtotime($orderCreatedDate));
             $orderSyncFromDate = StoreKeeperOptions::get(StoreKeeperOptions::ORDER_SYNC_FROM_DATE);
-            if (!is_null($orderSyncFromDate) && strtotime($orderCreatedDate) < strtotime($orderSyncFromDate)) {
-                return false;
+            if (!is_null($orderSyncFromDate) && strtotime($orderSyncFromDate) <= strtotime($orderCreatedDate)) {
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Tools/OrderHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tools/OrderHandler.php
@@ -110,7 +110,12 @@ class OrderHandler
             $orderCreatedDate = $order->get_date_created();
             $orderCreatedDate = date('Y-m-d', strtotime($orderCreatedDate));
             $orderSyncFromDate = StoreKeeperOptions::get(StoreKeeperOptions::ORDER_SYNC_FROM_DATE);
-            if (!is_null($orderSyncFromDate) && strtotime($orderSyncFromDate) <= strtotime($orderCreatedDate)) {
+
+            if (is_null($orderSyncFromDate)) {
+                return true;
+            }
+
+            if (strtotime($orderSyncFromDate) <= strtotime($orderCreatedDate)) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR includes:
1. Added new sync modes `Product only`, `No sync`.
![image](https://user-images.githubusercontent.com/18332309/143421994-34c3aa55-e1bb-4430-987c-04f66c45f8db.png)
2. Added ability to set order sync date from.
![image](https://user-images.githubusercontent.com/18332309/143422209-824626c9-67e0-49a8-b707-84958a56dd62.png)
3. Disabled payments for modes above.
![image](https://user-images.githubusercontent.com/18332309/143422316-57d07f71-065d-4edc-b65d-8bb12907e7a0.png)

