### PR TITLE
Moved setting of WP_ADMIN to true in superclass CommandRunner

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Commands/CommandRunner.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/CommandRunner.php
@@ -29,6 +29,12 @@ class CommandRunner
 
     public function __construct()
     {
+        // WP_ADMIN constant is being defined here as it causes synchronization issue of attribute types due to external plugins
+        // @see known plugin: https://themesinfo.com/wordpress-plugins/wordpress-wpa-woocommerce-variation-swatch-plugin-dksd/latest
+        // @see issue: https://app.clickup.com/t/1tm4vav
+        if (!defined('WP_ADMIN')) {
+            define('WP_ADMIN', true);
+        }
         $this->setLogger(new NullLogger());
     }
 

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/WpCliCommandRunner.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/WpCliCommandRunner.php
@@ -16,17 +16,6 @@ class WpCliCommandRunner extends CommandRunner
     const command_prefix = 'sk';
     const SINGLE_PROCESS = 'single-process';
 
-    public function __construct()
-    {
-        // WP_ADMIN constant is being defined here as it causes synchronization issue of attribute types due to external plugins
-        // @see known plugin: https://themesinfo.com/wordpress-plugins/wordpress-wpa-woocommerce-variation-swatch-plugin-dksd/latest
-        // @see issue: https://app.clickup.com/t/1tm4vav
-        if (!defined('WP_ADMIN')) {
-            define('WP_ADMIN', true);
-        }
-        parent::__construct();
-    }
-
     /**
      * @throws \Exception
      */

--- a/src/StoreKeeper/WooCommerce/B2C/Tools/Attributes.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tools/Attributes.php
@@ -446,7 +446,7 @@ class Attributes
         string $alias,
         string $title
     ): int {
-        // Refer admin issue on StoreKeeper\WooCommerce\B2C\Commands\WpCliCommandRunner::21
+        // Refer admin issue on StoreKeeper\WooCommerce\B2C\Commands\CommandRunner::32
         if (!is_admin()) {
             throw new WordpressException(__('Failed to execute attribute sync as WP_ADMIN constant is set to false', I18N::DOMAIN));
         }

--- a/tests/unit/Commands/CommandRunnerTrait.php
+++ b/tests/unit/Commands/CommandRunnerTrait.php
@@ -20,7 +20,7 @@ trait CommandRunnerTrait
     public function setUpRunner()
     {
         $this->logger = new TestLogger();
-        // Refer admin issue on StoreKeeper\WooCommerce\B2C\Commands\WpCliCommandRunner::21
+        // Refer admin issue on StoreKeeper\WooCommerce\B2C\Commands\CommandRunner::32
         define('WP_ADMIN', true);
         $this->runner = Core::getCommandRunner();
         $this->runner->setLogger($this->logger);


### PR DESCRIPTION
This PR includes:
1. Quick fix on an issue encountered during product import. 
![image](https://user-images.githubusercontent.com/18332309/143239527-980612f0-47a4-45da-8f00-4a752ed309e9.png)
2. Moved the WP_ADMIN set to parent constructor

_Note: Already tested again on CLI and Tools_