### PR TITLE
Added a new exception to catch when Order is non existent

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Exceptions/NonExistentObjectException.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Exceptions/NonExistentObjectException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace StoreKeeper\WooCommerce\B2C\Exceptions;
+
+class NonExistentObjectException extends BaseException
+{
+}

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/OrderImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/OrderImport.php
@@ -116,7 +116,7 @@ SQL;
 
         $response = $wpdb->get_row($safe_sql);
 
-        if (is_array($response) && array_key_exists('ID', $response)) {
+        if (isset($response->ID)) {
             return new WC_Order($response->ID);
         }
 


### PR DESCRIPTION
This PR includes:
1. Allow task to finish instead of fail for Orders that are not existing in Webshop but is created in backoffice.
![image](https://user-images.githubusercontent.com/18332309/143251530-1d480cfd-1a4c-4ddd-ba71-bc5a33aba411.png)
