### PR TITLE
Added checking upon initialization of pages

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractPage.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractPage.php
@@ -70,7 +70,7 @@ abstract class AbstractPage extends AbstractPageLike
     {
         $extensions = get_loaded_extensions();
         $missingExtensions = [];
-        foreach (self::REQUIRED_PHP_EXTENSION as $wantedExtension) {
+        foreach (static::REQUIRED_PHP_EXTENSION as $wantedExtension) {
             if (!in_array($wantedExtension, $extensions)) {
                 $missingExtensions[] = sprintf(__('PHP %s extension', I18N::DOMAIN), $wantedExtension);
             }

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractPage.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractPage.php
@@ -60,9 +60,31 @@ abstract class AbstractPage extends AbstractPageLike
 
     public function initialize()
     {
+        $this->checkExtensions();
         $this->triggerAction();
         $this->register();
         $this->render();
+    }
+
+    protected function checkExtensions(): void
+    {
+        $extensions = get_loaded_extensions();
+        $missingExtensions = [];
+        foreach (self::REQUIRED_PHP_EXTENSION as $wantedExtension) {
+            if (!in_array($wantedExtension, $extensions)) {
+                $missingExtensions[] = sprintf(__('PHP %s extension', I18N::DOMAIN), $wantedExtension);
+            }
+        }
+
+        if (!empty($missingExtensions)) {
+            AdminNotices::showError(
+                sprintf(
+                    esc_html__('The following required extensions are missing from your server: %s'),
+                    implode(', ', $missingExtensions),
+                ),
+                esc_html__('Contact your server provider to enable these extensions for the StoreKeeper synchronization plugin to function properly.')
+            );
+        }
     }
 
     private function triggerAction()

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractPageLike.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/AbstractPageLike.php
@@ -4,6 +4,15 @@ namespace StoreKeeper\WooCommerce\B2C\Backoffice\Pages;
 
 abstract class AbstractPageLike
 {
+    const REQUIRED_PHP_EXTENSION = [
+        'bcmath',
+        'json',
+        'mbstring',
+        'mysqli',
+        'openssl',
+        'zip',
+    ];
+
     public function register(): void
     {
         $this->doRegisterStyles();

--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/StatusTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/StatusTab.php
@@ -31,15 +31,6 @@ class StatusTab extends AbstractTab
         WooCommerceOptions::WOOCOMMERCE_TOKEN,
     ];
 
-    const REQUIRED_PHP_EXTENSION = [
-        'bcmath',
-        'json',
-        'mbstring',
-        'mysqli',
-        'openssl',
-        'zip',
-    ];
-
     protected function getStylePaths(): array
     {
         return [
@@ -158,7 +149,7 @@ class StatusTab extends AbstractTab
         ];
 
         $extensions = get_loaded_extensions();
-        foreach (self::REQUIRED_PHP_EXTENSION as $wantedExtension) {
+        foreach (static::REQUIRED_PHP_EXTENSION as $wantedExtension) {
             $data[] = [
                 'title' => sprintf(__('PHP %s extension', I18N::DOMAIN), $wantedExtension),
                 'description' => sprintf(


### PR DESCRIPTION
This PR includes:
1. Checking of extensions for all storekeeper plugin pages only.

See image below when bcmath is disabled:
![image](https://user-images.githubusercontent.com/18332309/145191661-4bc9e0bb-311d-4353-8a01-45d0e7569ade.png)
