### PR TITLE
Fixed double instruction rendered

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/SchedulerTab.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Pages/Tabs/SchedulerTab.php
@@ -174,9 +174,6 @@ class SchedulerTab extends AbstractTab
 
         if (!empty($instructions)) {
             $instructionsHTML = static::generateOrderedListHtml($instructions);
-            foreach ($instructions as $key => $instruction) {
-                $instructionsHTML .= '<p style="white-space: pre-line;">'.($key + 1).'. '.$instruction.'</p>';
-            }
 
             $this->renderFormGroup(
                 __('Instructions', I18N::DOMAIN),


### PR DESCRIPTION
This PR includes:
1. Fix for scheduler tab instruction being rendered twice.