### PR TITLE
Set has_fields and description to empty to hide payment infobar

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/PaymentGateway/StoreKeeperBaseGateway.php
+++ b/src/StoreKeeper/WooCommerce/B2C/PaymentGateway/StoreKeeperBaseGateway.php
@@ -26,7 +26,8 @@ class StoreKeeperBaseGateway extends \WC_Payment_Gateway
         $this->setIconUrl($icon_url);
         $this->title = $title;
 
-        $this->has_fields = true;
+        $this->has_fields = false;
+        $this->description = null;
         $this->method_title = 'StoreKeeper - '.$title;
 
         $this->init_form_fields();


### PR DESCRIPTION
This PR includes:
1. Setting all payment gateway from Storekeeper to no fields, and no description.

Note: Also tested using the magnifique's theme
**Before**
![2021-12-09_23-46](https://user-images.githubusercontent.com/18332309/145429575-67bc9732-3210-4d04-88ad-c69ca83d57cb.png)
**After**
![2021-12-09_23-47](https://user-images.githubusercontent.com/18332309/145429617-1cd2bd4b-1554-409b-b250-f4ff09be9a73.png)

