### PR TITLE
Change status to private if price is less than or equal to zero

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Imports/ProductImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/ProductImport.php
@@ -815,7 +815,7 @@ SQL;
         /* Pricing */
         // Regular price
         $newProduct->set_regular_price($pricePerUnit);
-        $log_data['regular_price'] = $dotObject->get($pricePerUnit);
+        $log_data['regular_price'] = $pricePerUnit;
         $this->debug('Set regular_price on product', $log_data);
 
         // WooCommece will only allow setting the sale price when it's lower then the regular price


### PR DESCRIPTION
This PR includes:
1. Changing the status to private.

Upon checking, I tried to import using CSV with 0 price, but the backoffice puts the product into unpublished status already.
![image](https://user-images.githubusercontent.com/18332309/146737046-fa9f6677-b8f9-4541-9689-be3eacadae07.png)
But just in case, I do the unpublishing on wordpress plugin side as well.