### PR TITLE
Added getting of order page URL and display to customer order view

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -130,3 +130,10 @@ Tagging a commit will trigger a release build on github.
 git tag 5.2.0
 git push origin 5.2.0
 ```
+## Development notes
+
+### Hooks
+1. `storekeeper_order_tracking_message` - Used for overriding the default message for track & trace on customer order page.
+   1. Type - `Filter`
+   2. Parameters - `$message`,`$url`
+   3. Triggering class - `StoreKeeper\WooCommerce\B2C\Frontend\Handlers\OrderHookHandler`

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/FrondendCore.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/FrondendCore.php
@@ -32,7 +32,7 @@ class FrondendCore
         $this->loader->add_filter('woocommerce_structured_data_product', $seo, 'addExtraSeoData', 10, 2);
 
         $orderHookHandler = new OrderHookHandler();
-        $this->loader->add_action('woocommerce_order_details_after_order_table', $orderHookHandler, 'addOrderStatusLink', 10); // Set priority to 9 to show on top of order details
+        $this->loader->add_action('woocommerce_order_details_after_order_table', $orderHookHandler, 'addOrderStatusLink');
         $this->loader->add_filter(OrderHookHandler::STOREKEEPER_ORDER_TRACK_HOOK, $orderHookHandler, 'createOrderTrackingMessage', 10, 2);
 
         $this->registerShortCodes();

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/FrondendCore.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/FrondendCore.php
@@ -2,6 +2,7 @@
 
 namespace StoreKeeper\WooCommerce\B2C\Frontend;
 
+use StoreKeeper\WooCommerce\B2C\Frontend\Handlers\OrderHookHandler;
 use StoreKeeper\WooCommerce\B2C\Frontend\Handlers\Seo;
 use StoreKeeper\WooCommerce\B2C\Frontend\Handlers\SubscribeHandler;
 use StoreKeeper\WooCommerce\B2C\Frontend\ShortCodes\FormShortCode;
@@ -29,6 +30,10 @@ class FrondendCore
 
         $seo = new Seo();
         $this->loader->add_filter('woocommerce_structured_data_product', $seo, 'addExtraSeoData', 10, 2);
+
+        $orderHookHandler = new OrderHookHandler();
+        $this->loader->add_action('woocommerce_view_order', $orderHookHandler, 'addOrderStatusLink', 9); // Set priority to 9 to show on top of order details
+
         $this->registerShortCodes();
         $this->registerHandlers();
         $this->loadWooCommerceTemplate();

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/FrondendCore.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/FrondendCore.php
@@ -32,7 +32,8 @@ class FrondendCore
         $this->loader->add_filter('woocommerce_structured_data_product', $seo, 'addExtraSeoData', 10, 2);
 
         $orderHookHandler = new OrderHookHandler();
-        $this->loader->add_action('woocommerce_view_order', $orderHookHandler, 'addOrderStatusLink', 9); // Set priority to 9 to show on top of order details
+        $this->loader->add_action('woocommerce_order_details_after_order_table', $orderHookHandler, 'addOrderStatusLink', 10); // Set priority to 9 to show on top of order details
+        $this->loader->add_filter(OrderHookHandler::STOREKEEPER_ORDER_TRACK_HOOK, $orderHookHandler, 'createOrderTrackingMessage', 10, 2);
 
         $this->registerShortCodes();
         $this->registerHandlers();

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/OrderHookHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/OrderHookHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace StoreKeeper\WooCommerce\B2C\Frontend\Handlers;
+
+use StoreKeeper\ApiWrapper\Exception\GeneralException;
+use StoreKeeper\WooCommerce\B2C\Factories\LoggerFactory;
+use StoreKeeper\WooCommerce\B2C\Helpers\HtmlEscape;
+use StoreKeeper\WooCommerce\B2C\I18N;
+use StoreKeeper\WooCommerce\B2C\Imports\OrderImport;
+use StoreKeeper\WooCommerce\B2C\Tools\StoreKeeperApi;
+
+class OrderHookHandler
+{
+    public function addOrderStatusLink(int $orderId)
+    {
+        $order = wc_get_order($orderId);
+        $orderPageStatusUrl = $order->get_meta(OrderImport::ORDER_PAGE_META_KEY, true);
+        $storekeeperId = $order->get_meta('storekeeper_id', true);
+        if (!empty($storekeeperId) && empty($orderPageStatusUrl)) {
+            try {
+                $apiWrapper = StoreKeeperApi::getApiByAuthName();
+                $shopModule = $apiWrapper->getModule('ShopModule');
+                $storekeeperOrder = $shopModule->getOrder($storekeeperId, null);
+                if (isset($storekeeperOrder['shipped_item_no'])) {
+                    $shippedItem = (int) $storekeeperOrder['shipped_item_no'];
+                    if ($shippedItem > 0) {
+                        OrderImport::fetchOrderStatusUrl($order, $storekeeperId);
+                    }
+                }
+
+                $orderPageStatusUrl = $order->get_meta(OrderImport::ORDER_PAGE_META_KEY, true);
+            } catch (GeneralException $generalException) {
+                LoggerFactory::create('order')->error($generalException->getMessage(), $generalException->getTrace());
+            }
+        }
+
+        if (!empty($orderPageStatusUrl)) {
+            $trackMessage = esc_html__('Your order is ready for track and trace.', I18N::DOMAIN);
+            $trackLink = wp_kses(
+                '<a href="'.$orderPageStatusUrl.'">'.
+                esc_html__('View here').
+                '</a>',
+                HtmlEscape::ALLOWED_ANCHOR
+            );
+            echo <<<HTML
+        $trackMessage $trackLink
+HTML;
+        }
+    }
+}

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/OrderHookHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/OrderHookHandler.php
@@ -37,7 +37,7 @@ class OrderHookHandler
         if (!empty($orderPageStatusUrl)) {
             $trackMessage = esc_html__('Your order is ready for track and trace.', I18N::DOMAIN);
             $trackLink = wp_kses(
-                '<a href="'.$orderPageStatusUrl.'">'.
+                '<a href="'.$orderPageStatusUrl.'" target="_blank">'.
                 esc_html__('View here').
                 '</a>',
                 HtmlEscape::ALLOWED_ANCHOR

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/SubscribeHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/SubscribeHandler.php
@@ -80,11 +80,11 @@ class SubscribeHandler
             if ('Subuser with this email already exists' === $e->getMessage()) {
                 self::stateRedirect('already_subscribed');
             } else {
-                $logger->error($e->getMessage(), $e->getTrace());
+                $logger->error($e->getMessage(), ['trace' => $e->getTraceAsString()]);
                 self::stateRedirect('error');
             }
         } catch (\Throwable $e) {
-            $logger->error($e->getMessage(), $e->getTrace());
+            $logger->error($e->getMessage(), ['trace' => $e->getTraceAsString()]);
         }
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/OrderImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/OrderImport.php
@@ -236,7 +236,7 @@ SQL;
             $order->update_meta_data(self::ORDER_PAGE_META_KEY, $orderStatusPageUrl);
             $order->save();
         } catch (GeneralException $generalException) {
-            LoggerFactory::create('order')->error($generalException->getMessage(), ['trace' => $generalException->getTrace()]);
+            LoggerFactory::create('order')->error($generalException->getMessage(), ['trace' => $generalException->getTraceAsString()]);
         }
 
         return $orderStatusPageUrl;

--- a/src/StoreKeeper/WooCommerce/B2C/PaymentGateway/PaymentGateway.php
+++ b/src/StoreKeeper/WooCommerce/B2C/PaymentGateway/PaymentGateway.php
@@ -270,7 +270,7 @@ SQL;
             $order->save();
         } catch (\Throwable $exception) {
             // Log error
-            LoggerFactory::create('checkout')->error($exception->getMessage(), $exception->getTrace());
+            LoggerFactory::create('checkout')->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
             LoggerFactory::createErrorTask('payment-error', $exception);
 
             // Update url
@@ -382,7 +382,7 @@ SQL;
                 );
             }
         } catch (AuthException $authException) {
-            LoggerFactory::create('checkout')->error($authException->getMessage(), $authException->getTrace());
+            LoggerFactory::create('checkout')->error($authException->getMessage(), ['trace' => $authException->getTraceAsString()]);
             LoggerFactory::createErrorTask('add-storeKeeper-gateway-auth', $authException);
 
             return $default_gateway_classes;

--- a/src/StoreKeeper/WooCommerce/B2C/PaymentGateway/StoreKeeperBaseGateway.php
+++ b/src/StoreKeeper/WooCommerce/B2C/PaymentGateway/StoreKeeperBaseGateway.php
@@ -52,7 +52,7 @@ class StoreKeeperBaseGateway extends \WC_Payment_Gateway
                 'redirect' => $this->getPaymentUrl($order),
             ];
         } catch (\Throwable $exception) {
-            LoggerFactory::create('checkout')->error($exception->getMessage(), $exception->getTrace());
+            LoggerFactory::create('checkout')->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
             LoggerFactory::createErrorTask('process-payment', $exception);
         }
 

--- a/tests/unit/Endpoints/Webhooks/UpdateOrderTest.php
+++ b/tests/unit/Endpoints/Webhooks/UpdateOrderTest.php
@@ -3,6 +3,7 @@
 namespace StoreKeeper\WooCommerce\B2C\UnitTest\Endpoints\Webhooks;
 
 use Adbar\Dot;
+use Mockery\MockInterface;
 use StoreKeeper\WooCommerce\B2C\Commands\CleanWoocommerceEnvironment;
 use StoreKeeper\WooCommerce\B2C\Commands\ProcessAllTasks;
 use StoreKeeper\WooCommerce\B2C\Imports\OrderImport;
@@ -87,6 +88,17 @@ class UpdateOrderTest extends AbstractTest
     protected function executeOrderUpdateTest(): void
     {
         $this->syncShopInformation();
+
+        StoreKeeperApi::$mockAdapter->withModule(
+            'ShopModule',
+            function (MockInterface $module) {
+                $module->shouldReceive('getOrderStatusPageUrl')->andReturnUsing(
+                    function ($got) {
+                        return 'https://test.storekeepercloud.com/apps/order-status/unit-test';
+                    }
+                );
+            }
+        );
 
         // Create order
         $wc_order_id = $this->createWooCommerceOrder();


### PR DESCRIPTION
This PR includes:
1. Fetching of status URL on order import.
2. Fetching of status URL when customer visits order view page.
3. Display link in the order view page for customer.
![image](https://user-images.githubusercontent.com/18332309/147639105-4976d36e-25ba-4e04-af87-fe8199167e13.png)

**Question: Should we also add a link/metabox on wordpress admin side?**