### PR TITLE
Fixed error when running subcommand with pagination when using full sync

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Commands/AbstractCommand.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/AbstractCommand.php
@@ -132,18 +132,32 @@ abstract class AbstractCommand implements CommandInterface
      *
      * @throws SubProcessException|BaseException
      */
-    protected function runSubCommandWithPagination(string $command_name, int $total_amount, int $amount = self::AMOUNT, bool $isOutputEcho = false): void
-    {
+    protected function runSubCommandWithPagination(
+        string $command_name,
+        int $total_amount,
+        int $amount = self::AMOUNT,
+        bool $isOutputEcho = false,
+        bool $hasPageArgument = false,
+        bool $hasStartArgument = false
+    ): void {
         $page = 0;
         for ($start = 0; $start < $total_amount; $start += $amount) {
+            $assocArguments = [
+                'limit' => $amount,
+            ];
+
+            if ($hasStartArgument) {
+                $assocArguments['start'] = $start;
+            }
+
+            if ($hasPageArgument) {
+                $assocArguments['page'] = $page;
+            }
+
             $this->executeSubCommand(
                 $command_name,
                 [],
-                [
-                    'start' => $start,
-                    'limit' => $amount,
-                    'page' => $page,
-                ],
+                $assocArguments,
                 $isOutputEcho
             );
             ++$page;

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/AbstractCommand.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/AbstractCommand.php
@@ -12,12 +12,15 @@ use StoreKeeper\WooCommerce\B2C\Exceptions\BaseException;
 use StoreKeeper\WooCommerce\B2C\Exceptions\NotConnectedException;
 use StoreKeeper\WooCommerce\B2C\Exceptions\SubProcessException;
 use StoreKeeper\WooCommerce\B2C\I18N;
+use StoreKeeper\WooCommerce\B2C\Interfaces\WithConsoleProgressBarInterface;
 use StoreKeeper\WooCommerce\B2C\Options\StoreKeeperOptions;
 use StoreKeeper\WooCommerce\B2C\Tools\StoreKeeperApi;
+use StoreKeeper\WooCommerce\B2C\Traits\ConsoleProgressBarTrait;
 
-abstract class AbstractCommand implements CommandInterface
+abstract class AbstractCommand implements CommandInterface, WithConsoleProgressBarInterface
 {
     use LoggerAwareTrait;
+    use ConsoleProgressBarTrait;
 
     const AMOUNT = 100;
 
@@ -109,7 +112,8 @@ abstract class AbstractCommand implements CommandInterface
         $name,
         array $arguments = [],
         array $assoc_arguments = [],
-        bool $isOutputEcho = false
+        bool $isOutputEcho = false,
+        bool $hideSubprocessProgressBar = false
     ): int {
         if (Core::isTest()) {
             // for tests we skip all the sub processing,
@@ -117,7 +121,7 @@ abstract class AbstractCommand implements CommandInterface
             $result = $this->runner->execute($name, $arguments, $assoc_arguments);
             $this->logger->warning(__CLASS__.'::'.__FILE__.' timeout option ignored');
         } else {
-            $result = $this->runner->executeAsSubProcess($name, $arguments, $assoc_arguments, $isOutputEcho);
+            $result = $this->runner->executeAsSubProcess($name, $arguments, $assoc_arguments, $isOutputEcho, $hideSubprocessProgressBar);
         }
 
         return $result;
@@ -138,9 +142,11 @@ abstract class AbstractCommand implements CommandInterface
         int $amount = self::AMOUNT,
         bool $isOutputEcho = false,
         bool $hasPageArgument = false,
-        bool $hasStartArgument = false
+        bool $hasStartArgument = false,
+        bool $hideSubprocessProgressBar = false
     ): void {
         $page = 0;
+        $this->createProgressBar(ceil($total_amount / $amount), __('Syncing from Storekeeper backoffice', I18N::DOMAIN));
         for ($start = 0; $start < $total_amount; $start += $amount) {
             $assocArguments = [
                 'limit' => $amount,
@@ -158,9 +164,13 @@ abstract class AbstractCommand implements CommandInterface
                 $command_name,
                 [],
                 $assocArguments,
-                $isOutputEcho
+                $isOutputEcho,
+                $hideSubprocessProgressBar
             );
+            $this->tickProgressBar();
             ++$page;
         }
+
+        $this->endProgressBar();
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/CommandRunner.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/CommandRunner.php
@@ -141,9 +141,14 @@ class CommandRunner
         string $name,
         array $arguments = [],
         array $assoc_arguments = [],
-        bool $isOutputEcho = false
+        bool $isOutputEcho = false,
+        bool $hideSubprocessProgressBar = false
     ): int {
         global $argv;
+        if ($hideSubprocessProgressBar) {
+            $assoc_arguments['hide-progress-bar'] = true;
+        }
+
         $input = self::getSubProcessInputString($name, $arguments, $assoc_arguments);
 
         if ($this->shouldSpawnSubProcess && !is_null($argv)) {
@@ -160,7 +165,7 @@ class CommandRunner
                 $params,
                 null,
                 600,
-                $isOutputEcho
+                $isOutputEcho,
             );
 
             return $process->getExitCode();
@@ -233,8 +238,12 @@ class CommandRunner
     /**
      * @throws SubProcessException
      */
-    protected function spawnSubProcess(array $params, string $input = null, int $timeout = 0, bool $isOutputEcho = false): Process
-    {
+    protected function spawnSubProcess(
+        array $params,
+        string $input = null,
+        int $timeout = 0,
+        bool $isOutputEcho = false
+    ): Process {
         $phpBinary = PHP_BINARY === '' ? 'php' : PHP_BINARY;
         $command = [$phpBinary];
         list($xdebug_on, $command) = $this->setXdebugCmsArgs($command);

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceAttributeOptionPage.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceAttributeOptionPage.php
@@ -33,6 +33,12 @@ class SyncWoocommerceAttributeOptionPage extends AbstractSyncCommand
                 'description' => __('Determines how many attribute options will be synchronized from the starting point.', I18N::DOMAIN),
                 'optional' => false,
             ],
+            [
+                'type' => 'flag',
+                'name' => 'hide-progress-bar',
+                'description' => __('Hide displaying of progress bar while executing command.', I18N::DOMAIN),
+                'optional' => true,
+            ],
         ];
     }
 

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceAttributeOptions.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceAttributeOptions.php
@@ -53,7 +53,10 @@ class SyncWoocommerceAttributeOptions extends AbstractSyncCommand
             $this->runSubCommandWithPagination(
                 SyncWoocommerceAttributeOptionPage::getCommandName(),
                 $total_amount,
-                self::AMOUNT
+                self::AMOUNT,
+                false,
+                false,
+                true
             );
         }
     }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceAttributeOptions.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceAttributeOptions.php
@@ -54,8 +54,9 @@ class SyncWoocommerceAttributeOptions extends AbstractSyncCommand
                 SyncWoocommerceAttributeOptionPage::getCommandName(),
                 $total_amount,
                 self::AMOUNT,
+                true,
                 false,
-                false,
+                true,
                 true
             );
         }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceCrossSellProducts.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceCrossSellProducts.php
@@ -54,7 +54,9 @@ class SyncWoocommerceCrossSellProducts extends AbstractSyncCommand
             $this->runSubCommandWithPagination(
                 SyncWoocommerceCrossSellProductPage::getCommandName(),
                 $total_amount,
-                self::AMOUNT_PER_PAGE
+                self::AMOUNT_PER_PAGE,
+                false,
+                true
             );
         }
     }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceCrossSellProducts.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceCrossSellProducts.php
@@ -46,7 +46,7 @@ class SyncWoocommerceCrossSellProducts extends AbstractSyncCommand
     {
         if ($this->prepareExecute()) {
             // Try to get the total amount from the assoc arguments, if they are not there calculate the total amount.
-            $total_amount = key_exists('total-amount', $assoc_arguments) ?
+            $total_amount = array_key_exists('total-amount', $assoc_arguments) ?
                 $assoc_arguments['total-amount'] :
                 ProductHelper::getAmountOfProductsInWooCommerce();
 
@@ -55,6 +55,8 @@ class SyncWoocommerceCrossSellProducts extends AbstractSyncCommand
                 SyncWoocommerceCrossSellProductPage::getCommandName(),
                 $total_amount,
                 self::AMOUNT_PER_PAGE,
+                true,
+                true,
                 false,
                 true
             );

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceFullSync.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceFullSync.php
@@ -92,10 +92,10 @@ class SyncWoocommerceFullSync extends AbstractSyncCommand
             $attribute_options_totals = $this->getAmountOfAttributeOptionsInBackend();
             $this->executeSubCommand(
                 SyncWoocommerceAttributeOptions::getCommandName(),
-                [
-                    'total_amount' => $attribute_options_totals,
-                ],
                 [],
+                [
+                    'total-amount' => $attribute_options_totals,
+                ],
                 true
             );
 
@@ -105,10 +105,10 @@ class SyncWoocommerceFullSync extends AbstractSyncCommand
                 $product_totals = $this->getAmountOfProductsInBackend();
                 $this->executeSubCommand(
                     SyncWoocommerceProducts::getCommandName(),
-                    [
-                        'total_amount' => $product_totals,
-                    ],
                     [],
+                    [
+                        'total-amount' => $product_totals,
+                    ],
                     true
                 );
             }
@@ -121,7 +121,7 @@ class SyncWoocommerceFullSync extends AbstractSyncCommand
                 // Get the total amount of products that should be sync
                 $cross_up_sell_product_totals = ProductHelper::getAmountOfProductsInWooCommerce();
                 $args = [
-                    'total_amount' => $cross_up_sell_product_totals,
+                    'total-amount' => $cross_up_sell_product_totals,
                 ];
 
                 if ($sync_upsell) {

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceProductPage.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceProductPage.php
@@ -38,6 +38,12 @@ class SyncWoocommerceProductPage extends AbstractSyncCommand
                 'description' => __('Determines how many products will be synchronized from the starting point.', I18N::DOMAIN),
                 'optional' => false,
             ],
+            [
+                'type' => 'flag',
+                'name' => 'hide-progress-bar',
+                'description' => __('Hide displaying of progress bar while executing command.', I18N::DOMAIN),
+                'optional' => true,
+            ],
         ];
     }
 

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceProducts.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceProducts.php
@@ -54,6 +54,7 @@ class SyncWoocommerceProducts extends AbstractSyncCommand
                 self::AMOUNT,
                 true,
                 false,
+                true,
                 true
             );
         }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceProducts.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceProducts.php
@@ -52,6 +52,8 @@ class SyncWoocommerceProducts extends AbstractSyncCommand
                 SyncWoocommerceProductPage::getCommandName(),
                 $total_amount,
                 self::AMOUNT,
+                true,
+                false,
                 true
             );
         }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceUpsellProductPage.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceUpsellProductPage.php
@@ -7,12 +7,15 @@ use StoreKeeper\WooCommerce\B2C\Exceptions\WordpressException;
 use StoreKeeper\WooCommerce\B2C\Helpers\WpCliHelper;
 use StoreKeeper\WooCommerce\B2C\I18N;
 use StoreKeeper\WooCommerce\B2C\Imports\ProductImport;
-use StoreKeeper\WooCommerce\B2C\Interfaces\WithConsoleProgressBarInterface;
-use StoreKeeper\WooCommerce\B2C\Traits\ConsoleProgressBarTrait;
 
-class SyncWoocommerceUpsellProductPage extends AbstractSyncCommand implements WithConsoleProgressBarInterface
+class SyncWoocommerceUpsellProductPage extends AbstractSyncCommand
 {
-    use ConsoleProgressBarTrait;
+    protected $isProgressBarShown = true;
+
+    public function setIsProgressBarShown(bool $isProgressBarShown): void
+    {
+        $this->isProgressBarShown = $isProgressBarShown;
+    }
 
     public static function getShortDescription(): string
     {
@@ -39,6 +42,12 @@ class SyncWoocommerceUpsellProductPage extends AbstractSyncCommand implements Wi
                 'description' => __('Determines how many upsell products will be synchronized from the starting point.', I18N::DOMAIN),
                 'optional' => false,
             ],
+            [
+                'type' => 'flag',
+                'name' => 'hide-progress-bar',
+                'description' => __('Hide displaying of progress bar while executing command.', I18N::DOMAIN),
+                'optional' => true,
+            ],
         ];
     }
 
@@ -49,7 +58,10 @@ class SyncWoocommerceUpsellProductPage extends AbstractSyncCommand implements Wi
     public function execute(array $arguments, array $assoc_arguments)
     {
         if ($this->prepareExecute()) {
-            if (key_exists('limit', $assoc_arguments) && key_exists('page', $assoc_arguments)) {
+            if (array_key_exists('hide-progress-bar', $assoc_arguments)) {
+                $this->setIsProgressBarShown(false);
+            }
+            if (array_key_exists('limit', $assoc_arguments) && array_key_exists('page', $assoc_arguments)) {
                 $this->runWithPagination($assoc_arguments);
             } else {
                 throw new BaseException('Limit and page attribute need to be set');
@@ -79,10 +91,12 @@ class SyncWoocommerceUpsellProductPage extends AbstractSyncCommand implements Wi
      */
     private function syncUpsellForProducts($products)
     {
-        $this->createProgressBar(count($products), WpCliHelper::setGreenOutputColor(sprintf(
-            __('Syncing %s from Storekeeper backoffice', I18N::DOMAIN),
-            __('upsell products', I18N::DOMAIN)
-        )));
+        if ($this->isProgressBarShown) {
+            $this->createProgressBar(count($products), WpCliHelper::setGreenOutputColor(sprintf(
+                __('Syncing %s from Storekeeper backoffice', I18N::DOMAIN),
+                __('upsell products', I18N::DOMAIN)
+            )));
+        }
         foreach ($products as $index => $product) {
             $this->logger->debug(
                 'Processing product',
@@ -99,11 +113,14 @@ class SyncWoocommerceUpsellProductPage extends AbstractSyncCommand implements Wi
                     'post_id' => $product->get_id(),
                 ]
             );
-
-            $this->tickProgressBar();
+            if ($this->isProgressBarShown) {
+                $this->tickProgressBar();
+            }
         }
 
-        $this->endProgressBar();
+        if ($this->isProgressBarShown) {
+            $this->endProgressBar();
+        }
     }
 
     /**

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceUpsellProducts.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceUpsellProducts.php
@@ -54,7 +54,9 @@ class SyncWoocommerceUpsellProducts extends AbstractSyncCommand
             $this->runSubCommandWithPagination(
                 SyncWoocommerceUpsellProductPage::getCommandName(),
                 $total_amount,
-                self::AMOUNT_PER_PAGE
+                self::AMOUNT_PER_PAGE,
+                false,
+                true
             );
         }
     }

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceUpsellProducts.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/SyncWoocommerceUpsellProducts.php
@@ -46,7 +46,7 @@ class SyncWoocommerceUpsellProducts extends AbstractSyncCommand
     {
         if ($this->prepareExecute()) {
             // Try to get the total amount from the assoc arguments, if they are not there calculate the total amount.
-            $total_amount = key_exists('total-amount', $assoc_arguments) ?
+            $total_amount = array_key_exists('total-amount', $assoc_arguments) ?
                 $assoc_arguments['total-amount'] :
                 ProductHelper::getAmountOfProductsInWooCommerce();
 
@@ -55,6 +55,8 @@ class SyncWoocommerceUpsellProducts extends AbstractSyncCommand
                 SyncWoocommerceUpsellProductPage::getCommandName(),
                 $total_amount,
                 self::AMOUNT_PER_PAGE,
+                true,
+                true,
                 false,
                 true
             );

--- a/src/StoreKeeper/WooCommerce/B2C/Commands/WebCommandRunner.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/WebCommandRunner.php
@@ -17,8 +17,12 @@ class WebCommandRunner extends CommandRunner
         return (int) $command->execute($arguments, $assoc_arguments);
     }
 
-    public function executeAsSubProcess(string $name, array $arguments = [], array $assoc_arguments = [], bool $isOutputEcho = false): int
-    {
+    public function executeAsSubProcess(
+        string $name, array $arguments = [],
+        array $assoc_arguments = [],
+        bool $isOutputEcho = false,
+        bool $hideSubprocessProgressBar = true
+    ): int {
         // web runner cannot execute as subprocess, just a normal execute instead
         return $this->execute($name, $arguments, $assoc_arguments);
     }

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/AbstractImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/AbstractImport.php
@@ -48,6 +48,18 @@ abstract class AbstractImport
 
     protected $processedItemCount = 0;
 
+    protected $isProgressBarShown = true;
+
+    public function setIsProgressBarShown(bool $isProgressBarShown): void
+    {
+        $this->isProgressBarShown = $isProgressBarShown;
+    }
+
+    protected function shouldShowProgressBar(): bool
+    {
+        return $this->isProgressBarShown && $this instanceof WithConsoleProgressBarInterface;
+    }
+
     /**
      * AbstractImport constructor.
      *
@@ -235,7 +247,7 @@ abstract class AbstractImport
                 $last_fetched_amount = (int) $response['count'];
                 $start = $start + ($last_fetched_amount - 1);
                 $items = $response['data'];
-                if ($this instanceof WithConsoleProgressBarInterface) {
+                if ($this->shouldShowProgressBar()) {
                     $this->createProgressBar(
                         $last_fetched_amount,
                         WpCliHelper::setGreenOutputColor(sprintf(
@@ -273,7 +285,7 @@ abstract class AbstractImport
                         );
                         throw $exception;
                     } finally {
-                        if ($this instanceof WithConsoleProgressBarInterface) {
+                        if ($this->shouldShowProgressBar()) {
                             $this->tickProgressBar();
                         }
                     }
@@ -281,7 +293,7 @@ abstract class AbstractImport
                 unset($items);
                 unset($response);
 
-                if ($this instanceof WithConsoleProgressBarInterface) {
+                if ($this->shouldShowProgressBar()) {
                     $this->endProgressBar();
                 }
             }

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/AttributeOptionImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/AttributeOptionImport.php
@@ -26,9 +26,12 @@ class AttributeOptionImport extends AbstractImport implements WithConsoleProgres
      */
     public function __construct(array $settings = [])
     {
-        $this->storekeeper_id = key_exists('storekeeper_id', $settings) ? (int) $settings['storekeeper_id'] : 0;
-        $this->attribute_id = key_exists('attribute_id', $settings) ? (int) $settings['attribute_id'] : 0;
-        $this->attribute_option_ids = key_exists(
+        if (array_key_exists('hide-progress-bar', $settings)) {
+            $this->setIsProgressBarShown(false);
+        }
+        $this->storekeeper_id = array_key_exists('storekeeper_id', $settings) ? (int) $settings['storekeeper_id'] : 0;
+        $this->attribute_id = array_key_exists('attribute_id', $settings) ? (int) $settings['attribute_id'] : 0;
+        $this->attribute_option_ids = array_key_exists(
             'attribute_option_ids',
             $settings
         ) ? (array) $settings['attribute_option_ids'] : [];

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/ProductImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/ProductImport.php
@@ -119,6 +119,14 @@ class ProductImport extends AbstractProductImport implements WithConsoleProgress
         return false;
     }
 
+    public function __construct(array $settings = [])
+    {
+        if (array_key_exists('hide-progress-bar', $settings)) {
+            $this->setIsProgressBarShown(false);
+        }
+        parent::__construct($settings);
+    }
+
     /**
      * @param Dot $dotObject
      *


### PR DESCRIPTION
This PR includes:
1. Fix for full sync command adding `page` and `start` assoc arguments even if not needed because of runSubCommandWithPagination.
2. Also throwing error because of `total_amount` changed to `total-amount`.

Tested working now:
Cross-sell:
![image](https://user-images.githubusercontent.com/18332309/148786107-3e998be3-cb73-4ac0-b2b7-be3feb54c68b.png)

Up-sell:
![image](https://user-images.githubusercontent.com/18332309/148786167-cf6df747-0428-49bf-8b4e-fdee02d0a814.png)

Products:
![image](https://user-images.githubusercontent.com/18332309/148786193-3df039dd-8a8f-48a8-93e7-dacc8ff9e255.png)

Full-sync (not full screenshot):
![image](https://user-images.githubusercontent.com/18332309/148790943-159a7fb6-638a-4a66-ae17-2d3f7e5f7be3.png)


