### PR TITLE
Fixed address checking not working, and UI adjustment

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/FrontendCore.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/FrontendCore.php
@@ -61,7 +61,7 @@ class FrontendCore
         $this->loader->add_filter('woocommerce_default_address_fields', $addressFormHandler, 'alterAddressForm', 11);
         $this->loader->add_filter('woocommerce_get_country_locale', $addressFormHandler, 'customLocale', 11);
         $this->loader->add_filter('woocommerce_country_locale_field_selectors', $addressFormHandler, 'customSelectors', 11);
-        $this->loader->add_action('woocommerce_account_edit-address_endpoint', $addressFormHandler, 'enqueueScriptsAndStyles');
+        $this->loader->add_action('woocommerce_before_edit_account_address_form', $addressFormHandler, 'enqueueScriptsAndStyles');
         $this->loader->add_action('woocommerce_after_save_address_validation', $addressFormHandler, 'validateCustomFields', 11, 2);
         $this->loader->add_action('woocommerce_checkout_process', $addressFormHandler, 'validateCustomFieldsForCheckout', 11, 2);
         $this->loader->add_action('woocommerce_checkout_create_order', $addressFormHandler, 'saveCustomFields');

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/AddressFormHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/AddressFormHandler.php
@@ -48,7 +48,10 @@ class AddressFormHandler
      */
     public function alterAddressForm(array $fields): array
     {
-        return $this->addFields($fields);
+        $fields = $this->addFields($fields);
+        $fields = $this->updateFields($fields);
+
+        return $fields;
     }
 
     /**
@@ -62,7 +65,7 @@ class AddressFormHandler
         ];
 
         $locale['NL']['postcode']['priority'] = 45;
-        $locale['NL']['postcode']['label'] = __('Postcode / ZIP & House number', I18N::DOMAIN);
+        $locale['NL']['postcode']['label'] = __('Postcode / ZIP', I18N::DOMAIN);
         $locale['NL']['postcode']['placeholder'] = __('Postcode / ZIP', I18N::DOMAIN);
 
         $locale['NL']['address_1'] = [
@@ -159,7 +162,7 @@ class AddressFormHandler
         }
     }
 
-    private function addFields(array $fields)
+    private function addFields(array $fields): array
     {
         $updatedFields = $this->insertFieldsAtPosition($fields, [
             self::HOUSE_NUMBER_FIELD => [
@@ -168,15 +171,23 @@ class AddressFormHandler
                 'type' => 'text',
                 'priority' => 50,
                 'hidden' => true,
-                'class' => ['form-row-wide', 'address-field'],
+                'class' => ['form-row-last', 'address-field'],
                 'label' => __('House number', I18N::DOMAIN),
-                'label_class' => ['screen-reader-text'],
             ],
         ],
             self::STREET_ADDRESS_POSITION
         );
 
         return $updatedFields;
+    }
+
+    private function updateFields(array $fields): array
+    {
+        $fields['address_1']['custom_attributes'] = ['readonly' => 'readonly'];
+        $fields['city']['custom_attributes'] = ['readonly' => 'readonly'];
+        $fields['postcode']['class'] = ['form-row-first', 'address-field'];
+
+        return $fields;
     }
 
     private function insertFieldsAtPosition(array $originalFields, array $newFields, int $position): array

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/AddressFormHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/Handlers/AddressFormHandler.php
@@ -69,6 +69,7 @@ class AddressFormHandler
         $locale['NL']['postcode']['placeholder'] = __('Postcode / ZIP', I18N::DOMAIN);
 
         $locale['NL']['address_1'] = [
+            'label' => __('Street address', I18N::DOMAIN),
             'placeholder' => __('Street name', I18N::DOMAIN),
             'priority' => 55,
         ];

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/assets/storekeeper-address-form.js
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/assets/storekeeper-address-form.js
@@ -37,8 +37,8 @@ jQuery(function ($) {
                 const houseNumber = $(houseNumberInput).val();
                 $(postCodeContainer).removeClass('woocommerce-validated').removeClass('woocommerce-invalid');
                 $(houseNumberContainer).removeClass('woocommerce-validated').removeClass('woocommerce-invalid');
-                $(houseNumberContainer).find('.postcode-housenr-validation-message').remove();
-                $(houseNumberContainer).append(`<small class="postcode-housenr-validation-message">${window.storekeeperTranslate('Validating postcode and house number. Please wait...')}</small>`);
+                $(postCodeContainer).find('.postcode-housenr-validation-message').remove();
+                $(postCodeContainer).append(`<small class="postcode-housenr-validation-message">${window.storekeeperTranslate('Validating postcode and house number. Please wait...')}</small>`);
                 $.ajax({
                     url: settings.url,
                     data: {
@@ -51,15 +51,15 @@ jQuery(function ($) {
                     $(`#${formPrefix}_city`).val(city);
                     $(postCodeContainer).addClass('woocommerce-validated');
                     $(houseNumberContainer).addClass('woocommerce-validated');
-                    $(houseNumberContainer).find('.postcode-housenr-validation-message').remove();
-                    $(houseNumberContainer).append(`<small class="postcode-housenr-validation-message" style="color: green">${window.storekeeperTranslate('Valid postcode and house number')}</small>`);
+                    $(postCodeContainer).find('.postcode-housenr-validation-message').remove();
+                    $(postCodeContainer).append(`<small class="postcode-housenr-validation-message" style="color: green">${window.storekeeperTranslate('Valid postcode and house number')}</small>`);
                     resolve();
                 }).fail(function (xhrText, textStatus) {
                     window.storekeeperUnblockForm(parentForm);
                     $(postCodeContainer).addClass('woocommerce-invalid');
                     $(houseNumberContainer).addClass('woocommerce-invalid');
-                    $(houseNumberContainer).find('.postcode-housenr-validation-message').remove();
-                    $(houseNumberContainer).append(`<small class="postcode-housenr-validation-message" style="color: red">${window.storekeeperTranslate('Invalid postcode or house number')}</small>`);
+                    $(postCodeContainer).find('.postcode-housenr-validation-message').remove();
+                    $(postCodeContainer).append(`<small class="postcode-housenr-validation-message" style="color: red">${window.storekeeperTranslate('Invalid postcode or house number')}</small>`);
                     reject();
                 });
             });
@@ -108,8 +108,8 @@ jQuery(function ($) {
                     if (!dutchPostcodeRegex.test(postCode)) {
                         isValid = false;
                         $(postCodeContainer).addClass('woocommerce-invalid');
-                        $(houseNumberContainer).find('.postcode-housenr-validation-message').remove();
-                        $(houseNumberContainer).append(`<small class="postcode-housenr-validation-message" style="color: red">${window.storekeeperTranslate('Postcode format for NL address is invalid')}</small>`);
+                        $(postCodeContainer).find('.postcode-housenr-validation-message').remove();
+                        $(postCodeContainer).append(`<small class="postcode-housenr-validation-message" style="color: red">${window.storekeeperTranslate('Postcode format for NL address is invalid')}</small>`);
                     } else {
                         isValid = true;
                         window.storekeeperFetchAddressFromBackend(formPrefix, form).then(function () {
@@ -147,7 +147,7 @@ jQuery(function ($) {
     }
 
     let formPrefix = settings.addressType;
-    if (formPrefix === null) {
+    if (!formPrefix) {
         for (let index in settings.defaultAddressTypes) {
             const formPrefix = settings.defaultAddressTypes[index];
             prepareAddressForm(formPrefix);


### PR DESCRIPTION
This PR includes:
1. Adjustments for UI of address
2. Fix for address checking not working.

**Issue:**
The issue before was due to the translation/permalinks.
https://candynow.nl/my-account/edit-address/facturatie/
The `addressType` becomes `facturatie` in this page which results to scripts not being applied to DOM elements.

Screenshot of new UI:
![image](https://user-images.githubusercontent.com/18332309/175569133-cb065eb6-c6e0-403f-b072-90e12c951692.png)
