### PR TITLE
Order synchronization ignore deleted woocommerce products

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Exports/OrderExport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Exports/OrderExport.php
@@ -550,7 +550,7 @@ class OrderExport extends AbstractExport
                 if ($isVariation) {
                     /**
                      * @var $meta_datum WC_Meta_Data
-                     *                  This is the met data that is set on the product order, for a variation product that.
+                     *                  This is the metadata that is set on the product order, for a variation product that.
                      *                  More info about meta_data: https://docs.woocommerce.com/wc-apidocs/class-WC_Data.html
                      */
                     $metaData = $orderProduct->get_meta_data();


### PR DESCRIPTION
This PR includes:
1. Skipping of products that are already removed in WooCommerce to be checked for differences.
2. Variable convention fixes