### PR TITLE
House number improvements

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Database/DatabaseConnection.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Database/DatabaseConnection.php
@@ -133,12 +133,17 @@ class DatabaseConnection
             $dateTimeClone->setTimezone(new \DateTimeZone('UTC'));
         }
 
-        return $dateTimeClone->format(DateTimeHelper::MYSQL_DATE_FORMAT);
+        return $dateTimeClone->format(DateTimeHelper::MYSQL_DATETIME_FORMAT);
     }
 
     public static function formatFromDatabaseDate(string $date): \DateTime
     {
-        $formattedDate = \DateTime::createFromFormat(DateTimeHelper::MYSQL_DATE_FORMAT, $date, new \DateTimeZone('UTC'));
+        $formattedDate = \DateTime::createFromFormat(DateTimeHelper::MYSQL_DATETIME_FORMAT, $date, new \DateTimeZone('UTC'));
+
+        if (!$formattedDate) {
+            // If date has no time
+            $formattedDate = \DateTime::createFromFormat(DateTimeHelper::MYSQL_DATE_FORMAT, $date, new \DateTimeZone('UTC'));
+        }
 
         if (!$formattedDate) {
             // Fallback in case the date is not in mysql format

--- a/src/StoreKeeper/WooCommerce/B2C/Frontend/FrontendCore.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Frontend/FrontendCore.php
@@ -65,8 +65,12 @@ class FrontendCore
         $this->loader->add_filter('woocommerce_default_address_fields', $addressFormHandler, 'alterAddressForm', 11);
         $this->loader->add_filter('woocommerce_get_country_locale', $addressFormHandler, 'customLocale', 11);
         $this->loader->add_filter('woocommerce_country_locale_field_selectors', $addressFormHandler, 'customSelectors', 11);
+        $this->loader->add_filter('woocommerce_billing_fields', $addressFormHandler, 'setHouseNumberValueFromSession', 11);
+        $this->loader->add_filter('woocommerce_shipping_fields', $addressFormHandler, 'setHouseNumberValueFromSession', 11);
+
         $this->loader->add_action('woocommerce_before_edit_account_address_form', $addressFormHandler, 'enqueueScriptsAndStyles');
         $this->loader->add_action('woocommerce_checkout_create_order', $addressFormHandler, 'saveCustomFields');
+        $this->loader->add_action('woocommerce_checkout_process', $addressFormHandler, 'saveCustomFieldsToSession');
         $this->loader->add_action('woocommerce_before_checkout_form', $addressFormHandler, 'addCheckoutScripts', 11);
     }
 

--- a/src/StoreKeeper/WooCommerce/B2C/Helpers/DateTimeHelper.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Helpers/DateTimeHelper.php
@@ -9,7 +9,8 @@ use StoreKeeper\WooCommerce\B2C\I18N;
 
 class DateTimeHelper
 {
-    const MYSQL_DATE_FORMAT = 'Y-m-d H:i:s';
+    const MYSQL_DATETIME_FORMAT = 'Y-m-d H:i:s';
+    const MYSQL_DATE_FORMAT = 'Y-m-d';
     const WORDPRESS_DATE_FORMAT_OPTION = 'date_format';
     const WORDPRESS_TIME_FORMAT_OPTION = 'time_format';
 

--- a/tests/unit/Exports/AbstractOrderExportTest.php
+++ b/tests/unit/Exports/AbstractOrderExportTest.php
@@ -36,7 +36,7 @@ abstract class AbstractOrderExportTest extends AbstractExportTest
         return $order->save();
     }
 
-    protected function getOrderProps(bool $isNlCountry = false): array
+    protected function getOrderProps(bool $isNlCountry = false, string $houseNumber = ''): array
     {
         $faker = $this->faker;
         $vals = [
@@ -48,13 +48,13 @@ abstract class AbstractOrderExportTest extends AbstractExportTest
         foreach ($vals as $k => $val) {
             $order[$k] = $val;
         }
-        $order += $this->getAddress('billing_', $isNlCountry);
-        $order += $this->getAddress('shipping_', $isNlCountry);
+        $order += $this->getAddress('billing_', $isNlCountry, $houseNumber);
+        $order += $this->getAddress('shipping_', $isNlCountry, $houseNumber);
 
         return $order;
     }
 
-    protected function getAddress($prefix, bool $isNlCountry = false): array
+    protected function getAddress($prefix, bool $isNlCountry = false, string $houseNumber = ''): array
     {
         $faker = $this->faker;
         $vals = [
@@ -69,7 +69,10 @@ abstract class AbstractOrderExportTest extends AbstractExportTest
             'state' => $faker->state,
         ];
 
-        $houseNumber = $faker->randomNumber();
+        if (empty($houseNumber)) {
+            $houseNumber = $faker->randomNumber();
+        }
+
         if ($isNlCountry) {
             $vals['address_house_number'] = $houseNumber;
         }

--- a/tests/unit/Exports/OrderExportTest.php
+++ b/tests/unit/Exports/OrderExportTest.php
@@ -100,7 +100,9 @@ class OrderExportTest extends AbstractOrderExportTest
         ];
 
         if ('NL' === $wc_order->get_billing_country()) {
-            $expect_billing['address_billing']['streetnumber'] = $new_order['billing_address_house_number'];
+            $splitStreet = OrderExport::splitStreetNumber($new_order['billing_address_house_number']);
+            $expect_billing['address_billing']['streetnumber'] = $splitStreet['streetnumber'];
+            $expect_billing['address_billing']['flatnumber'] = $splitStreet['flatnumber'];
         }
         if (!empty($new_order['billing_company'])) {
             $expect_billing['business_data'] = [
@@ -136,7 +138,9 @@ class OrderExportTest extends AbstractOrderExportTest
             ];
 
             if ('NL' === $wc_order->get_shipping_country()) {
-                $expect_shipping['contact_address']['streetnumber'] = $new_order['shipping_address_house_number'];
+                $splitStreet = OrderExport::splitStreetNumber($new_order['shipping_address_house_number']);
+                $expect_shipping['contact_address']['streetnumber'] = $splitStreet['streetnumber'];
+                $expect_shipping['contact_address']['flatnumber'] = $splitStreet['flatnumber'];
             }
         }
 
@@ -464,21 +468,120 @@ class OrderExportTest extends AbstractOrderExportTest
         $this->processNewOrder($new_order_id, $new_order);
     }
 
-    public function testOrderCreateWithNlCountry()
+    public function dataProviderOrderCreateWithNlCountry()
+    {
+        $tests = [];
+
+        $tests['with street number and flat number'] = [
+            'houseNumber' => '146A02B',
+            'expectedStreetNumber' => '146',
+            'expectedFlatNumber' => 'A02B',
+        ];
+
+        $tests['with street number only'] = [
+            'houseNumber' => '1011',
+            'expectedStreetNumber' => '1011',
+            'expectedFlatNumber' => '',
+        ];
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider dataProviderOrderCreateWithNlCountry
+     */
+    public function testOrderCreateWithNlCountry(string $houseNumber, string $expectedStreetNumber, string $expectedFlatNumber)
     {
         $this->initApiConnection();
 
-        $this->mockApiCallsFromDirectory(self::DATA_DUMP_FOLDER_CREATE, true);
+        $this->mockApiCallsFromDirectory(self::DATA_DUMP_FOLDER_CREATE);
 
         $this->emptyEnvironment();
 
-        $newOrderWithNlCountry = $this->getOrderProps(true);
+        $newOrderWithNlCountry = $this->getOrderProps(true, $houseNumber);
         $newOrderWithNlCountryId = $this->createWooCommerceOrder($newOrderWithNlCountry);
         $woocommerceOrder = new \WC_Order($newOrderWithNlCountryId);
         $woocommerceOrder->update_meta_data('billing_address_house_number', $newOrderWithNlCountry['billing_address_house_number']);
         $woocommerceOrder->update_meta_data('shipping_address_house_number', $newOrderWithNlCountry['shipping_address_house_number']);
         $woocommerceOrder->save();
-        $this->processNewOrder($newOrderWithNlCountryId, $newOrderWithNlCountry);
+
+        // this is normally created when the woocommerce_checkout_order_processed hook is fired
+        // StoreKeeper\WooCommerce\B2C\Core::setOrderHooks
+        $orderHandler = new OrderHandler();
+        $task = $orderHandler->create($newOrderWithNlCountryId);
+
+        // set the checker for expected result
+        $skOrderId = mt_rand();
+        $skCustomerId = mt_rand();
+
+        $sentOrders = [];
+        StoreKeeperApi::$mockAdapter->withModule(
+            'ShopModule',
+            function (MockInterface $module) use ($skCustomerId, $skOrderId, $newOrderWithNlCountry, $newOrderWithNlCountryId, &$sentOrders, $expectedStreetNumber, $expectedFlatNumber) {
+                $module->allows('newOrder')
+                    ->andReturnUsing(
+                        function ($got) use ($newOrderWithNlCountryId, $skCustomerId, $newOrderWithNlCountry, $skOrderId, &$sentOrders) {
+                            [$order] = $got;
+
+                            $this->assertNewOrder($newOrderWithNlCountryId, $skCustomerId, $newOrderWithNlCountry, $order);
+
+                            $sentOrders = $order;
+                            $sentOrders['id'] = $skOrderId;
+                            $sentOrders = $this->calculateNewOrder($sentOrders);
+
+                            return $skOrderId;
+                        }
+                    );
+
+                $module->allows('findShopCustomerBySubuserEmail')
+                    ->andReturnUsing(
+                        function () {
+                            return null; // Returning null here will cause method to call newShopCustomer instead
+                        }
+                    );
+                $module->allows('getOrder')
+                    ->andReturnUsing(
+                        function ($got) use (&$sentOrders, $skOrderId) {
+                            $this->assertEquals($skOrderId, $got[0]);
+
+                            return $sentOrders;
+                        }
+                    );
+
+                $module->allows('newShopCustomer')
+                    ->andReturnUsing(function ($got) use ($expectedStreetNumber, $expectedFlatNumber, $skCustomerId) {
+                        $data = $got[0];
+                        $shippingAddress = $data['relation']['contact_address'];
+                        $billingAddress = $data['relation']['address_billing'];
+
+                        $this->assertEquals($expectedStreetNumber, $shippingAddress['streetnumber'], 'Expected shipping address street number does not match');
+                        $this->assertEquals($expectedFlatNumber, $shippingAddress['flatnumber'], 'Expected shipping address flat number does not match');
+
+                        $this->assertEquals($expectedStreetNumber, $billingAddress['streetnumber'], 'Expected billing address street number does not match');
+                        $this->assertEquals($expectedFlatNumber, $billingAddress['flatnumber'], 'Expected billing address flat number does not match');
+
+                        return $skCustomerId;
+                    });
+
+                /*
+                 * Unrelated-calls for this test
+                 */
+                $module->allows('updateOrder')->andReturnUsing(
+                    function () {
+                        return null;
+                    }
+                );
+            }
+        );
+
+        // run the sync
+        $this->processTask($task);
+
+        $this->assertEquals(
+            $skOrderId,
+            get_post_meta($newOrderWithNlCountryId, 'storekeeper_id', true),
+            'storekeeper_id is assigned on wordpress order'
+        );
     }
 
     public function testOrderCreateWithEmballage()
@@ -721,14 +824,14 @@ class OrderExportTest extends AbstractOrderExportTest
         $task = $OrderHandler->create($new_order_id);
 
         // set the checker for expected result
-        $sk_order_id = rand();
-        $sk_customer_id = rand();
+        $sk_order_id = mt_rand();
+        $sk_customer_id = mt_rand();
 
         $sent_order = [];
         StoreKeeperApi::$mockAdapter->withModule(
             'ShopModule',
             function (MockInterface $module) use ($sk_customer_id, $sk_order_id, $new_order, $new_order_id, &$sent_order) {
-                $module->shouldReceive('newOrder')
+                $module->allows('newOrder')
                     ->andReturnUsing(
                         function ($got) use ($new_order_id, $sk_customer_id, $new_order, $sk_order_id, &$sent_order) {
                             [$order] = $got;
@@ -743,7 +846,7 @@ class OrderExportTest extends AbstractOrderExportTest
                         }
                     );
 
-                $module->shouldReceive('findShopCustomerBySubuserEmail')
+                $module->allows('findShopCustomerBySubuserEmail')
                     ->andReturnUsing(
                         function ($got) use ($sk_customer_id, $new_order) {
                             $this->assertEquals($new_order['billing_email'], $got[0]['email']);
@@ -754,7 +857,7 @@ class OrderExportTest extends AbstractOrderExportTest
                             ];
                         }
                     );
-                $module->shouldReceive('getOrder')
+                $module->allows('getOrder')
                     ->andReturnUsing(
                         function ($got) use (&$sent_order, $sk_order_id) {
                             $this->assertEquals($sk_order_id, $got[0]);
@@ -766,7 +869,7 @@ class OrderExportTest extends AbstractOrderExportTest
                 /*
                  * Unrelated-calls for this test
                  */
-                $module->shouldReceive('updateOrder')->andReturnUsing(
+                $module->allows('updateOrder')->andReturnUsing(
                     function () {
                         return null;
                     }


### PR DESCRIPTION
This PR includes:
1. Saving of house number during checkout on session for it to be shown when refreshed/visited checkout again.
2. Added street number and house number in request data if available during creation of customer.
3. Unit tests