### PR TITLE
Better exception message for order item differences

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Exceptions/OrderDifferenceException.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Exceptions/OrderDifferenceException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace StoreKeeper\WooCommerce\B2C\Exceptions;
+
+class OrderDifferenceException extends BaseException
+{
+}

--- a/src/StoreKeeper/WooCommerce/B2C/Factories/LoggerFactory.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Factories/LoggerFactory.php
@@ -132,7 +132,7 @@ class LoggerFactory
     /**
      * @param $custom_metadata
      */
-    public static function generateMetadata(string $key, \Throwable $exception, array $custom_metadata): array
+    public static function generateMetadata(string $key, \Throwable $exception, array $customMetadata): array
     {
         $metadata = [
             'error-key' => $key,
@@ -143,8 +143,9 @@ class LoggerFactory
             'exception-class' => get_class($exception),
         ];
 
-        $full_metadata = array_merge($metadata, $custom_metadata);
+        $fullMetadata = array_merge($metadata, $customMetadata);
+        $fullMetadata['exception-message'] = $metadata['exception-message'];
 
-        return $full_metadata;
+        return $fullMetadata;
     }
 }

--- a/src/StoreKeeper/WooCommerce/B2C/Tasks/OrderExportTask.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tasks/OrderExportTask.php
@@ -2,12 +2,14 @@
 
 namespace StoreKeeper\WooCommerce\B2C\Tasks;
 
+use Exception;
 use StoreKeeper\WooCommerce\B2C\Exports\OrderExport;
+use Throwable;
 
 class OrderExportTask extends AbstractTask
 {
     /**
-     * @throws \Exception
+     * @throws Exception|Throwable
      */
     public function run(array $task_options = []): void
     {


### PR DESCRIPTION
This PR includes:
1. Better exception message when order items has difference
2. Unit test
3. Changed logic to save exception message from generated metadata instead of the saved one.