### PR TITLE
Fixed false positive errors for orders

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/InfoHandler.php
@@ -172,19 +172,24 @@ class InfoHandler
         $orderSystemStatus['last_synchronized_date'] = TaskModel::getLatestSuccessfulSynchronizedDateForType(TaskHandler::ORDERS_EXPORT);
 
         $failedOrderIds = TaskModel::getFailedOrderIds();
-        $failedOrdersQuery = new \WC_Order_Query([
-            'post__in' => $failedOrderIds,
-            'orderby' => 'ID',
-            'order' => 'ASC',
-        ]);
-        $failedOrders = $failedOrdersQuery->get_orders();
-        // Order query by multiple status don't work so we have to filter manually
-        $failedOrdersWithoutCancelled = array_filter($failedOrders, static function (WC_Order $order) {
-            return OrderExport::STATUS_CANCELLED !== $order->get_status();
-        });
-        $failedOrderIdsWithoutCancelled = array_map(static function (WC_Order $order) {
-            return $order->get_id();
-        }, $failedOrdersWithoutCancelled);
+        $failedOrderIdsWithoutCancelled = [];
+        if (!empty($failedOrderIds)) {
+            $failedOrdersQuery = new \WC_Order_Query([
+                'post__in' => $failedOrderIds,
+                'orderby' => 'ID',
+                'order' => 'ASC',
+            ]);
+
+            $failedOrders = $failedOrdersQuery->get_orders();
+
+            // Order query by multiple status don't wmakork so we have to filter manually
+            $failedOrdersWithoutCancelled = array_filter($failedOrders, static function (WC_Order $order) {
+                return OrderExport::STATUS_CANCELLED !== $order->get_status();
+            });
+            $failedOrderIdsWithoutCancelled = array_map(static function (WC_Order $order) {
+                return $order->get_id();
+            }, $failedOrdersWithoutCancelled);
+        }
 
         $orderSystemStatus['ids_with_failed_tasks'] = $failedOrderIdsWithoutCancelled;
 

--- a/tests/unit/Endpoints/Webhooks/InfoHandlerTest.php
+++ b/tests/unit/Endpoints/Webhooks/InfoHandlerTest.php
@@ -181,6 +181,30 @@ class InfoHandlerTest extends AbstractTest
         $this->assertCount(0, $failedCompatibilityChecks, 'Failed compatibility checks should return 1 (woocommerce_manage_stock)');
     }
 
+    public function testFreshWebshop()
+    {
+        $this->initApiConnection();
+
+        $this->mockApiCallsFromDirectory(self::DATA_DUMP_FOLDER, false);
+        update_option('woocommerce_currency', 'EUR');
+
+        $successfulOrderId = $this->createWoocommerceOrder();
+        $this->exportOrder($successfulOrderId);
+
+        $file = $this->getHookDataDump('hook.info.json');
+        $rest = $this->getRestWithToken($file);
+
+        $response = $this->handleRequest($rest);
+        $data = $response->get_data();
+        $extra = $data['extra'];
+        $systemStatus = $extra['system_status'];
+        $orderSystemStatus = $systemStatus['order'];
+
+        // Assert order system status
+        $this->assertCount(0, $orderSystemStatus['ids_not_synchronized'], 'Not synchronized IDs should match with extras');
+        $this->assertCount(0, $orderSystemStatus['ids_with_failed_tasks'], 'Failed order IDs should match with extras');
+    }
+
     /**
      * @throws \WC_Data_Exception
      */


### PR DESCRIPTION
This PR includes:
1. Do not perform the WC_Order_Query if failed order IDs have no result.