### PR TITLE
fix: handling order payment status change

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Commands/ProcessAllTasks.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Commands/ProcessAllTasks.php
@@ -246,12 +246,13 @@ class ProcessAllTasks extends AbstractCommand
 
         $select = TaskModel::getSelectHelper()
             ->cols(['id'])
-            ->where('type IN (:type1,:type2,:type3)')
+            ->where('type IN (:type1,:type2,:type3,:type4)')
             ->where('status = :status')
             ->bindValue('status', TaskHandler::STATUS_NEW)
             ->bindValue('type1', TaskHandler::ORDERS_IMPORT)
             ->bindValue('type2', TaskHandler::ORDERS_EXPORT)
             ->bindValue('type3', TaskHandler::ORDERS_DELETE)
+            ->bindValue('type4', TaskHandler::ORDERS_PAYMENT_STATUS_CHANGE)
             ->limit(100);
 
         $query = $db->prepare($select);
@@ -266,12 +267,13 @@ class ProcessAllTasks extends AbstractCommand
 
         $select = TaskModel::getSelectHelper()
             ->cols(['id'])
-            ->where('type NOT IN (:type1,:type2,:type3)')
+            ->where('type NOT IN (:type1,:type2,:type3,:type4)')
             ->where('status = :status')
             ->bindValue('status', TaskHandler::STATUS_NEW)
             ->bindValue('type1', TaskHandler::ORDERS_IMPORT)
             ->bindValue('type2', TaskHandler::ORDERS_EXPORT)
             ->bindValue('type3', TaskHandler::ORDERS_DELETE)
+            ->bindValue('type4', TaskHandler::ORDERS_PAYMENT_STATUS_CHANGE)
             ->orderBy(['times_ran ASC', 'id ASC'])
             ->limit(100);
 

--- a/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Endpoints/Webhooks/EventsHandler.php
@@ -317,6 +317,21 @@ class EventsHandler
             case 'ShopModule::Order::deleted':
                 TaskHandler::scheduleTask(TaskHandler::PRODUCT_DELETE, $this->getId(), $taskData);
                 break;
+            case 'ShopModule::Order::payment_status_change':
+                if (isset($details['payment']['status']) && 'expired' === $details['payment']['status']) {
+                    // Only handle expired payments for now
+                    $metaData = [
+                        'order' => json_encode($details['order'], JSON_THROW_ON_ERROR),
+                        'payment' => json_encode($details['payment'], JSON_THROW_ON_ERROR),
+                    ];
+                    TaskHandler::scheduleTask(
+                        TaskHandler::ORDERS_PAYMENT_STATUS_CHANGE,
+                        $this->getId(),
+                        array_merge($taskData, $metaData),
+                        true
+                    );
+                }
+                break;
         }
     }
 

--- a/src/StoreKeeper/WooCommerce/B2C/Tasks/OrderPaymentStatusUpdateTask.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tasks/OrderPaymentStatusUpdateTask.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace StoreKeeper\WooCommerce\B2C\Tasks;
+
+class OrderPaymentStatusUpdateTask extends AbstractTask
+{
+    public function run(array $task_options = []): void
+    {
+        if (
+            $this->taskMetaExists('storekeeper_id')
+            && $this->taskMetaExists('order')
+            && $this->taskMetaExists('payment')
+        ) {
+            $storekeeper_id = $this->getTaskMeta('storekeeper_id');
+            $order = $this->getTaskMeta('order');
+            $payment = $this->getTaskMeta('payment');
+
+            $orderData = json_decode($order, true, 512, JSON_THROW_ON_ERROR);
+            $paymentData = json_decode($payment, true, 512, JSON_THROW_ON_ERROR);
+
+            if ('expired' === $paymentData['status'] && 'cancelled' !== $orderData['status']) {
+                $wcOrder = $this->getOrderByStoreKeeperId($storekeeper_id);
+                if ($wcOrder && 'cancelled' !== $wcOrder->get_status()) {
+                    // This will trigger OrderHandler::updateWithIgnore already so it will create an order export task
+                    $wcOrder->set_status('cancelled');
+                    $wcOrder->save();
+                }
+            }
+        }
+    }
+
+    /**
+     * @return false|\WC_Order
+     */
+    protected function getOrderByStoreKeeperId($storekeeper_id)
+    {
+        global $wpdb;
+
+        $sql = <<<SQL
+SELECT ID FROM {$wpdb->prefix}posts
+INNER JOIN {$wpdb->prefix}postmeta
+ON {$wpdb->prefix}posts.ID={$wpdb->prefix}postmeta.post_id
+WHERE {$wpdb->prefix}postmeta.meta_key='storekeeper_id'
+AND {$wpdb->prefix}postmeta.meta_value=%d
+AND {$wpdb->prefix}posts.post_type='shop_order'
+SQL;
+
+        $safe_sql = $wpdb->prepare($sql, $storekeeper_id);
+
+        $response = $wpdb->get_row($safe_sql);
+
+        if (isset($response->ID)) {
+            return new \WC_Order($response->ID);
+        }
+
+        return false;
+    }
+}

--- a/src/StoreKeeper/WooCommerce/B2C/Tools/TaskHandler.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tools/TaskHandler.php
@@ -22,6 +22,7 @@ use StoreKeeper\WooCommerce\B2C\Tasks\MenuItemImportTask;
 use StoreKeeper\WooCommerce\B2C\Tasks\OrderDeleteTask;
 use StoreKeeper\WooCommerce\B2C\Tasks\OrderExportTask;
 use StoreKeeper\WooCommerce\B2C\Tasks\OrderImportTask;
+use StoreKeeper\WooCommerce\B2C\Tasks\OrderPaymentStatusUpdateTask;
 use StoreKeeper\WooCommerce\B2C\Tasks\ParentProductRecalculationTask;
 use StoreKeeper\WooCommerce\B2C\Tasks\ProductActivateTask;
 use StoreKeeper\WooCommerce\B2C\Tasks\ProductDeactivateTask;
@@ -70,6 +71,7 @@ class TaskHandler
 
     public const ORDERS_EXPORT = 'orders-export';
     public const ORDERS_IMPORT = 'orders-import';
+    public const ORDERS_PAYMENT_STATUS_CHANGE = 'orders-payment-status-change';
     public const ORDERS_DELETE = 'orders-delete';
     public const SHIPPING_METHOD_IMPORT = 'shipping-method-import';
     public const SHIPPING_METHOD_DELETE = 'shipping-method-delete';
@@ -199,6 +201,7 @@ class TaskHandler
             case self::ORDERS_EXPORT:
             case self::ORDERS_IMPORT:
             case self::ORDERS_DELETE:
+            case self::ORDERS_PAYMENT_STATUS_CHANGE:
                 return self::ORDER_TYPE_GROUP;
             case self::TRIGGER_VARIATION_SAVE_ACTION:
                 return self::TRIGGER_VARIATION_SAVE_ACTION_TYPE_GROUP;
@@ -284,6 +287,9 @@ class TaskHandler
                 break;
             case self::ORDERS_IMPORT:
                 $title = __('Order import', I18N::DOMAIN)."(id=$id)";
+                break;
+            case self::ORDERS_PAYMENT_STATUS_CHANGE:
+                $title = __('Order payment status change')."(id=$id)";
                 break;
             case self::CATEGORY_DELETE:
                 $title = __('Delete category', I18N::DOMAIN)."(id=$id)";
@@ -459,6 +465,9 @@ class TaskHandler
                 break;
             case self::ORDERS_IMPORT:
                 $import = new OrderImportTask();
+                break;
+            case self::ORDERS_PAYMENT_STATUS_CHANGE:
+                $import = new OrderPaymentStatusUpdateTask();
                 break;
             case self::CATEGORY_DELETE:
                 $import = new CategoryDeleteTask();

--- a/tests/data/events/updateOrder/hook.events.paymentStatusChange.expired.json
+++ b/tests/data/events/updateOrder/hook.events.paymentStatusChange.expired.json
@@ -1,0 +1,66 @@
+{
+    "success": true,
+    "call_id": "662e92f7db6eb",
+    "request": {
+        "headers": {
+            "host": [
+                "junmar-wp.code4.pizza"
+            ],
+            "user_agent": [
+                "GuzzleHttp\/7"
+            ],
+            "content_length": [
+                "1907"
+            ],
+            "accept_encoding": [
+                "gzip"
+            ],
+            "cdn_loop": [
+                "cloudflare"
+            ],
+            "cf_connecting_ip": [
+                "2a01:4f9:5a:1c8a::2"
+            ],
+            "cf_ipcountry": [
+                "FI"
+            ],
+            "cf_ray": [
+                "87b90e147eac0109-AMS"
+            ],
+            "cf_visitor": [
+                "{\"scheme\":\"http\"}"
+            ],
+            "cf_warp_tag_id": [
+                "397aecd1-040c-47aa-a53b-89ed30c83997"
+            ],
+            "connection": [
+                "keep-alive"
+            ],
+            "content_type": [
+                "application\/json"
+            ],
+            "upxhooktoken": [
+                "e7c433888a2aa9684c2d1120baa5a28641e65205bf6d1531fe82c512ca0a375d"
+            ],
+            "x_forwarded_for": [
+                "2a01:4f9:5a:1c8a::2"
+            ],
+            "x_forwarded_proto": [
+                "http"
+            ]
+        },
+        "body": "{\"action\":\"events\",\"payload\":{\"date_newest\":\"2024-04-28 20:18:24+02\",\"backref\":\"ShopModule::Order(id=951)\",\"events\":{\"13248\":{\"id\":13248,\"event\":\"payment_status_change\",\"details\":{\"order\":{\"id\":\"951\",\"number\":\"S29-27\",\"status\":\"on_hold\",\"is_paid\":false,\"shop_id\":\"29\",\"is_contract\":false,\"is_quote\":false,\"location_id\":\"2\"},\"payment\":{\"id\":\"664\",\"provider_id\":\"10\",\"method\":\"SandBox\",\"amount\":\"1210.0000\",\"currency_iso3\":\"EUR\",\"is_test\":false,\"title\":\"Bestelnummer: 27\",\"description\":null,\"reference_no\":null,\"metadata\":{\"product_sent_to_pay\":true},\"status\":\"expired\",\"date_created\":\"2024-04-28 17:44:11+02\",\"date_updated\":\"2024-04-28 20:18:24+02\",\"date_expires_on\":null,\"date_paid\":null,\"date_canceled\":null,\"date_expired\":null,\"date_refunded\":null,\"payment_url\":\"https:\\\/\\\/api.pay.nl\\\/controllers\\\/payments\\\/issuer.php?orderId=2435920041X56553&entranceCode=33f3d549e1b561bab02df241efeb9abcde5d1758&profileID=613&lang=NL\",\"redirect_url\":\"http:\\\/\\\/junmar-wp.code4.pizza\\\/?wc-api=backoffice_pay_gateway_return&utm_nooverride=1&wc-order-id=27&trx=662e6ecb-0dd9-4e70-a312-8e97987beb62\",\"eid\":\"2435920041X56553\",\"relation_data_id\":\"278\",\"amount_refunded\":null,\"amount_no_tax\":null,\"provider_method_id\":\"17\",\"parent_id\":null,\"trx\":\"662e6ecb-0dd9-4e70-a312-8e97987beb62\",\"amount_refunded_no_tax\":null,\"is_virtual\":false,\"relation_data_snapshot_id\":\"201\",\"end_user_ip\":\"172.26.0.1\",\"products\":\"[{\\\"sku\\\": \\\"Iphone 13 Pro Max\\\", \\\"name\\\": \\\"Apple Iphone 13 Pro Max\\\", \\\"ppu_wt\\\": \\\"1210.00\\\", \\\"quantity\\\": 1, \\\"is_payment\\\": false, \\\"is_discount\\\": false, \\\"is_shipping\\\": false}]\",\"provider_method_option_type_id\":null,\"sales_person_id\":null,\"order_number\":null,\"invoice_number\":null,\"provider_method\":{\"id\":\"17\",\"title\":\"iDEAL\",\"eid\":\"10\",\"image_url\":\"https:\\\/\\\/static.pay.nl\\\/payment_profiles\\\/50x50\\\/10.png\",\"image_big_url\":null,\"provider_method_type_id\":\"1\",\"extra\":null}}},\"date\":\"2024-04-28 20:18:24+02\"}}}}",
+        "route": "\/storekeeper-woocommerce-b2c\/v1\/webhook",
+        "method": "POST",
+        "query_params": {
+            "rest_route": "\/storekeeper-woocommerce-b2c\/v1\/webhook\/"
+        },
+        "file_params": []
+    },
+    "hook_action": "events",
+    "return": true,
+    "_type": "hook",
+    "time_ms": 1086.0,
+    "_version": "1.0",
+    "_timestamp": "2024-04-28T18:18:32+00:00"
+}


### PR DESCRIPTION
## What?
[8694dzg50](https://app.clickup.com/t/8694dzg50) Handling order payment status change from backend events
## Why?
Payments that are being expired does not notify the web shops that those payments are expired, which causes the orders to remain open
## How?
Added task handling for web hooks that contains payment_status_change_event
## Anything Else?
Related to https://github.com/storekeeper-company/app-backend/pull/629