### PR TITLE
fix: woocommerce latest update adjustment for shop order post type

### DIFF
--- a/src/StoreKeeper/WooCommerce/B2C/Backoffice/Notices/AdminNotices.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Backoffice/Notices/AdminNotices.php
@@ -2,6 +2,7 @@
 
 namespace StoreKeeper\WooCommerce\B2C\Backoffice\Notices;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use StoreKeeper\WooCommerce\B2C\Cron\CronRegistrar;
 use StoreKeeper\WooCommerce\B2C\Database\DatabaseConnection;
 use StoreKeeper\WooCommerce\B2C\Helpers\DateTimeHelper;
@@ -140,7 +141,7 @@ class AdminNotices
     {
         global $post_type;
 
-        if ($this->isPostPage() && 'edit' === $this->getRequestAction() && 'shop_order' === $post_type) {
+        if ($this->isPostPage() && 'edit' === $this->getRequestAction() && in_array(['shop_order', DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE], $post_type, true)) {
             $id = $this->getRequestPostId();
             $goid = get_post_meta($id, 'storekeeper_id', true);
             $order = new \WC_Order($id);

--- a/src/StoreKeeper/WooCommerce/B2C/Imports/OrderImport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Imports/OrderImport.php
@@ -110,30 +110,25 @@ class OrderImport extends AbstractImport
     }
 
     /**
-     * @return bool|\WC_Order
+     * @return false|\WC_Order
      */
-    private function getItem($storekeeper_id)
+    protected function getItem($storekeeper_id)
     {
-        global $wpdb;
+        $args = [
+            'meta_key' => 'storekeeper_id',
+            'meta_value' => $storekeeper_id,
+        ];
+        $orders = wc_get_orders($args);
 
-        $sql = <<<SQL
-SELECT ID FROM {$wpdb->prefix}posts
-INNER JOIN {$wpdb->prefix}postmeta
-ON {$wpdb->prefix}posts.ID={$wpdb->prefix}postmeta.post_id
-WHERE {$wpdb->prefix}postmeta.meta_key='storekeeper_id'
-AND {$wpdb->prefix}postmeta.meta_value=%d
-AND {$wpdb->prefix}posts.post_type='shop_order'
-SQL;
-
-        $safe_sql = $wpdb->prepare($sql, $storekeeper_id);
-
-        $response = $wpdb->get_row($safe_sql);
-
-        if (isset($response->ID)) {
-            return new \WC_Order($response->ID);
+        if (count($orders) > 1) {
+            throw new \RuntimeException('More than one order found for storekeeper id'.$storekeeper_id);
         }
 
-        return false;
+        if (0 === count($orders)) {
+            return false;
+        }
+
+        return current($orders);
     }
 
     public static function getWoocommerceStatus($storekeeper_status)

--- a/src/StoreKeeper/WooCommerce/B2C/Tasks/OrderPaymentStatusUpdateTask.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Tasks/OrderPaymentStatusUpdateTask.php
@@ -18,6 +18,7 @@ class OrderPaymentStatusUpdateTask extends AbstractTask
 
             if ('expired' === $paymentData['status']) {
                 $wcOrder = $this->getOrderByStoreKeeperId($storekeeper_id);
+
                 if ($wcOrder && 'cancelled' !== $wcOrder->get_status()) {
                     // This will trigger OrderHandler::updateWithIgnore already so it will create an order export task
                     $wcOrder->set_status('cancelled');
@@ -32,25 +33,20 @@ class OrderPaymentStatusUpdateTask extends AbstractTask
      */
     protected function getOrderByStoreKeeperId($storekeeper_id)
     {
-        global $wpdb;
+        $args = [
+            'meta_key' => 'storekeeper_id',
+            'meta_value' => $storekeeper_id,
+        ];
+        $orders = wc_get_orders($args);
 
-        $sql = <<<SQL
-SELECT ID FROM {$wpdb->prefix}posts
-INNER JOIN {$wpdb->prefix}postmeta
-ON {$wpdb->prefix}posts.ID={$wpdb->prefix}postmeta.post_id
-WHERE {$wpdb->prefix}postmeta.meta_key='storekeeper_id'
-AND {$wpdb->prefix}postmeta.meta_value=%d
-AND {$wpdb->prefix}posts.post_type='shop_order'
-SQL;
-
-        $safe_sql = $wpdb->prepare($sql, $storekeeper_id);
-
-        $response = $wpdb->get_row($safe_sql);
-
-        if (isset($response->ID)) {
-            return new \WC_Order($response->ID);
+        if (count($orders) > 1) {
+            throw new \RuntimeException('More than one order found for storekeeper id'.$storekeeper_id);
         }
 
-        return false;
+        if (0 === count($orders)) {
+            return false;
+        }
+
+        return current($orders);
     }
 }


### PR DESCRIPTION
## What?
[8694dzg50](https://app.clickup.com/t/8694dzg50) Getting orders in database now uses the woocommerce function
## Why?
WooCommerce has an update called `High Performance Order Storage` which so happens that the post type of orders are now `shop_order_placehold` instead of `shop_order`. Some of our queries manually checks for `shop_order` therefore causes the issue that the order is not found.

See this forum:
https://wordpress.org/support/topic/post-type-change-breaks-wp_query/
## How?
Used wc_get_orders and filter via meta key and value.
Also adjusted OrderImport and OrderSyncMetabox which no longer show because of the said condition above.
## Anything Else?
There is a settings now in `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` where you can use the legacy `shop_order` or sync the orders to new ones `shop_order_placehold` and vice versa.
![image](https://github.com/storekeeper-company/storekeeper-woocommerce-b2c/assets/18332309/a34ba0ed-33e4-4781-b13f-4933e9c91a5f)
