### PR TITLE
Add company name instead of full_name

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -76,7 +76,7 @@ jobs:
             storekeeper-for-woocommerce/Readme.txt \
             storekeeper-for-woocommerce/.distignore
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: storekeeper-for-woocommerce
           if-no-files-found: error

--- a/src/StoreKeeper/WooCommerce/B2C/Exports/OrderExport.php
+++ b/src/StoreKeeper/WooCommerce/B2C/Exports/OrderExport.php
@@ -221,7 +221,7 @@ class OrderExport extends AbstractExport
          * Billing address
          */
         $callData['billing_address'] = [
-            'name' => $order->get_formatted_billing_full_name(),
+            'name' => !empty($order->get_billing_company(self::CONTEXT)) ? $order->get_billing_company(self::CONTEXT) : $order->get_formatted_billing_full_name(),
             'address_billing' => [
                 'state' => $order->get_billing_state(self::CONTEXT),
                 'city' => $order->get_billing_city(self::CONTEXT),
@@ -270,7 +270,7 @@ class OrderExport extends AbstractExport
          */
         if ($order->has_shipping_address()) {
             $callData['shipping_address'] = [
-                'name' => $order->get_formatted_shipping_full_name(),
+                'name' => !empty($order->get_shipping_company(self::CONTEXT)) ? $order->get_shipping_company(self::CONTEXT) : $order->get_formatted_shipping_full_name(),
                 'contact_address' => [
                     'state' => $order->get_shipping_state(self::CONTEXT),
                     'city' => $order->get_shipping_city(self::CONTEXT),
@@ -279,7 +279,7 @@ class OrderExport extends AbstractExport
                         $order->get_shipping_address_2(self::CONTEXT)
                     ),
                     'country_iso2' => $order->get_shipping_country(self::CONTEXT),
-                    'name' => $order->get_formatted_shipping_full_name(),
+                    'name' => !empty($order->get_shipping_company(self::CONTEXT)) ? $order->get_shipping_company(self::CONTEXT) : $order->get_formatted_shipping_full_name(),
                 ],
                 'contact_set' => [
                     'email' => $order->get_billing_email(self::CONTEXT),

--- a/tests/unit/Exports/OrderExportTest.php
+++ b/tests/unit/Exports/OrderExportTest.php
@@ -1771,7 +1771,7 @@ class OrderExportTest extends AbstractOrderExportTest
         $expectedBillingStreet = $new_order['billing_address_1'].' '.$new_order['billing_address_2'];
 
         $expect_billing = [
-            'name' => $new_order['billing_first_name'].' '.$new_order['billing_last_name'],
+            'name' => !empty($new_order['billing_company']) ? $new_order['billing_company'] : $new_order['billing_first_name'].' '.$new_order['billing_last_name'],
             'isprivate' => empty($new_order['billing_company']),
             'address_billing' => [
                 'state' => $new_order['billing_state'],
@@ -1813,7 +1813,7 @@ class OrderExportTest extends AbstractOrderExportTest
             $expectedShippingStreet = $new_order['shipping_address_1'].' '.$new_order['shipping_address_2'];
 
             $expect_shipping = [
-                'name' => $new_order['shipping_first_name'].' '.$new_order['shipping_last_name'],
+                'name' => !empty($new_order['shipping_company']) ? $new_order['shipping_company'] : $new_order['shipping_first_name'].' '.$new_order['shipping_last_name'],
                 'isprivate' => empty($new_order['shipping_company']),
                 'contact_address' => [
                     'state' => $new_order['shipping_state'],
@@ -1821,7 +1821,7 @@ class OrderExportTest extends AbstractOrderExportTest
                     'zipcode' => $new_order['shipping_postcode'],
                     'street' => $expectedShippingStreet,
                     'country_iso2' => $new_order['shipping_country'],
-                    'name' => $new_order['shipping_first_name'].' '.$new_order['shipping_last_name'],
+                    'name' => !empty($new_order['shipping_company']) ? $new_order['shipping_company'] : $new_order['shipping_first_name'].' '.$new_order['shipping_last_name'],
                 ],
                 'contact_set' => [
                     'email' => $new_order['billing_email'],


### PR DESCRIPTION


When a company places an order the company name should be synced as name. Otherwise the full_name is duplicated on the invoice. Including company name with full_name as fallback fixes this. Tested in test environment. 